### PR TITLE
Enable c++14 in compiler correctly when using CMake

### DIFF
--- a/tmxlite/CMakeLists.txt
+++ b/tmxlite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(tmxlite)
 SET(PROJECT_NAME tmxlite)
 
@@ -11,13 +11,8 @@ endif()
 
 SET(PROJECT_STATIC_RUNTIME FALSE CACHE BOOL "Use statically linked standard/runtime libraries?")
 
-if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
-  if(PROJECT_STATIC_RUNTIME)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14 -static")
-  else()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14")
-  endif()
-endif()
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(TMXLITE_STATIC_LIB)
   SET(CMAKE_CXX_FLAGS_DEBUG "-g -D_DEBUG_ -DTMXLITE_STATIC")

--- a/tmxlite/CMakeLists.txt
+++ b/tmxlite/CMakeLists.txt
@@ -11,6 +11,14 @@ endif()
 
 SET(PROJECT_STATIC_RUNTIME FALSE CACHE BOOL "Use statically linked standard/runtime libraries?")
 
+if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
+  if(PROJECT_STATIC_RUNTIME)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -static")
+  else()
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  endif()
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
A little change, Fixes compiling with clang.

The only downside is the small increase in cmake version required