### PR TITLE
Corrected an error with "trans" attribute

### DIFF
--- a/tmxlite/src/ImageLayer.cpp
+++ b/tmxlite/src/ImageLayer.cpp
@@ -75,7 +75,7 @@ void ImageLayer::parse(const pugi::xml_node& node)
             m_filePath = resolveFilePath(attribName, m_workingDir);
             if (child.attribute("trans"))
             {
-                attribName = node.attribute("trans").as_string();
+                attribName = child.attribute("trans").as_string();
                 m_transparencyColour = colourFromString(attribName);
                 m_hasTransparency = true;
             }


### PR DESCRIPTION
Hello,

For a project, I would like to use an ImageLayer with the transparent colour set. I noticed that there was a typo in the part handling this attribute and I corrected it. I didn't find an issue opened for this "bug" and I didn't want to open one for something I could correct directly.

Have a nice day!