### PR TITLE
Tileset image

### DIFF
--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -86,8 +86,6 @@ namespace tmx
             Vector2u imageSize;
             /*!
                 \brief The position of the tile within the image.
-
-                Used for an image tileset
             */
             Vector2u imagePosition;
             std::string type;

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -84,6 +84,12 @@ namespace tmx
             ObjectGroup objectGroup;
             std::string imagePath;
             Vector2u imageSize;
+            /*!
+                \brief The position of the tile within the image.
+
+                Used for an image tileset
+            */
+            Vector2u imagePosition;
             std::string type;
         };
             
@@ -206,6 +212,7 @@ namespace tmx
         void parsePropertyNode(const pugi::xml_node&);
         void parseTerrainNode(const pugi::xml_node&);
         void parseTileNode(const pugi::xml_node&);
+        void createMissingTile(std::uint32_t ID);
     };
 }
 

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -85,7 +85,7 @@ namespace tmx
             std::string imagePath;
             Vector2u imageSize;
             /*!
-                \brief The position of the tile within the image.
+            \brief The position of the tile within the image.
             */
             Vector2u imagePosition;
             std::string type;
@@ -178,7 +178,7 @@ namespace tmx
         const std::vector<Terrain>& getTerrainTypes() const { return m_terrainTypes; }
         /*!
         \brief Returns a reference to the vector of tile data used by
-        tiles which make up this tile set, if it is a collection of images.
+        tiles which make up this tile set.
         */
         const std::vector<Tile>& getTiles() const { return m_tiles; }
 


### PR DESCRIPTION
Hello,

I modified the Tileset implementation to support "Tileset Image". So, now, a tileset based on a single image is loaded as well. The tiles have the same interface regardless of the tileset's type.

I added an attribute to Tileset::Tile to store the position of the tile in the image. For a collection of image, it's always (0, 0) but, for a tileset image, the position depends on the tile's ID.