### PR TITLE
Corrected visible attribute in Object

### DIFF
--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -65,7 +65,9 @@ void Object::parse(const pugi::xml_node& node)
     m_AABB.height = node.attribute("height").as_float();
     m_rotation = node.attribute("rotation").as_float();
     m_tileID = node.attribute("gid").as_uint();
-    m_visible = node.attribute("visible").as_bool();
+    pugi::xml_attribute vis = node.attribute("visible");
+    if (vis)
+        m_visible = vis.as_bool();
 
     for (const auto& child : node.children())
     {

--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -65,9 +65,7 @@ void Object::parse(const pugi::xml_node& node)
     m_AABB.height = node.attribute("height").as_float();
     m_rotation = node.attribute("rotation").as_float();
     m_tileID = node.attribute("gid").as_uint();
-    pugi::xml_attribute vis = node.attribute("visible");
-    if (vis)
-        m_visible = vis.as_bool();
+    m_visible = node.attribute("visible").as_bool(true);
 
     for (const auto& child : node.children())
     {


### PR DESCRIPTION
Hello!

I noticed a little "bug" in the Object class: if the attribute of a pugixml node does not exist, as_bool() returns false... But, if the "visible" attribute is not present, it must be considered as true. So, I just added a condition to check if the attribute exists ;)