### PR TITLE
fix bug: last tile is always omitted

### DIFF
--- a/SFMLExample/src/SFMLOrthogonalLayer.hpp
+++ b/SFMLExample/src/SFMLOrthogonalLayer.hpp
@@ -194,7 +194,7 @@ private:
                     for (auto x = xPos; x < xPos + chunkTileCount.x; ++x)
                     {
                         if (idx < m_chunkTileIDs.size() && m_chunkTileIDs[idx].ID >= ca->m_firstGID
-                            && m_chunkTileIDs[idx].ID < ca->m_lastGID)
+                            && m_chunkTileIDs[idx].ID <= ca->m_lastGID)
                         {
                             sf::Vector2f tileOffset(x * mapTileSize.x, y * mapTileSize.y + mapTileSize.y - ca->tileSetSize.y);
 


### PR DESCRIPTION
I think this is a small bug making it impossible to use the last tile in a tileset