### PR TITLE
Vcpkg port

### DIFF
--- a/cmake/modules/FindTMXLITE.cmake
+++ b/cmake/modules/FindTMXLITE.cmake
@@ -1,0 +1,10 @@
+find_path(TMXLITE_INCLUDE_DIR NAMES tmxlite/Config.hpp PATH_SUFFIXES include)
+
+find_library(TMXLITE_LIBRARY_DEBUG NAMES tmxlite-d)
+find_library(TMXLITE_LIBRARY_RELEASE NAMES tmxlite)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(TMXLITE)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(TMXLITE DEFAULT_MSG TMXLITE_LIBRARY TMXLITE_INCLUDE_DIR)


### PR DESCRIPTION
Hi,

I've recently ported your library to vcpkg (https://github.com/Microsoft/vcpkg/).
I needed to modify the FindTMXLITE.cmake file because it couldn't find the debug configuration when using cmake with Visual Studio.

You may also want to update the SFML example because it no longer uses the FindSFML.cmake file (see this post: https://en.sfml-dev.org/forums/index.php?topic=24070.0).