### PR TITLE
Add support for <group> layer tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ ReleaseStatic
 /tmxlite/bin
 Debug
 Release
+
+*.swp

--- a/ParseTest/maps/platform.tmx
+++ b/ParseTest/maps/platform.tmx
@@ -7,24 +7,30 @@
  <tileset firstgid="43" name="tileset02" tilewidth="32" tileheight="32" tilecount="24" columns="6">
   <image source="../images/tilemap/tileset02.png" width="192" height="128"/>
  </tileset>
- <layer name="Far" width="200" height="40">
-  <data encoding="base64" compression="zlib">
-   eJzt2VsKwyAQBdCsoo8VNN3/BvvbQC1Em9iZOQeE/AQcyFXjLAuc69YxIKuePMgLVckCtNkz4LvrjgGVXHYMqGZPPuSFSuQCPrt3Dshudt/jOfAuZLfOngD8MfmANvkY43ya22P2BIKzvkCbfECbfECb8ykAAABnqNb/qlYvY6rdX0avV77PVe3+Mnq90fMNv/a+Z8gHbK2NZ2B7Jox+PqQO/8rQZi0HAAAAiCf7nWf2+jhW9v5u9vo41sj3E2Ftlg9GjPTMIvTbIswRYKYXswgSvA==
-  </data>
- </layer>
- <layer name="Middle" width="200" height="40">
+ <group name="TestGroup">
   <properties>
-   <property name="test layer property" type="bool" value="true"/>
+   <property name="layer group prop" value="hello"/>
+   <property name="another property" type="bool" value="false"/>
   </properties>
-  <data encoding="base64" compression="zlib">
-   eJztm9tOw0AMBc0DPAEfAKIY6P9/I6kgqA25NInXa3dnpCOeqJxmZ+89CgCMcfwNAPwHPwCmwQ+AafDDlrvaBYAp+GHLZ5fDIF9VK4I94AfU4qXL60LeqlX3A34ATIMfvrA+yQV++MC6JCf4AdkpOSbjB2RmbFy2HJvxw5bh+2IOlRv8iA9rehueujwO8rzwP/gRk6l5A+PSNua+z7nvEj/KsqXPuhW2jHvRxkr8KMfWPmsN0dqTdnkvlA+/x/ijZT/G+vYM/XuksxSVyzZ8LBxvT1r1g/n9PlR8fJiKlyOt+gHbUKnrhbcj+AFLqPjNn6LNt/AjLyXniCpxnfAcS/ADelRyOeHhCH7ACZX67dvSkdO+99T+5FzO9y7vzz63BaKdFURBpX67tozVecv5Z94Kpzl5/3yHkb/s3V6iUr89Zwi0h0r9dpclUI+18+S58/1r5pAqedfg+NEOKuXuKl07ryb4sYZr+nKL+1kq9d85wY81LJ23WZy9qdCHZ0x2ou/dquBF5mRGJeZvB3pU6r9f0p4fKuv6ZG9H1tZH4iYTKtvbnYcje+ojMZMFlf3PWtIRi/pIvERHxbZPLuGIGtZHYiUiKmXPtKzW7X2dtd8hKZcH2XYf2CrDMzd1fPY9jnjWSeqmxl2HKHcgstRJ/PMNRu5JzA==
-  </data>
- </layer>
- <layer name="Near" width="200" height="40">
-  <data encoding="base64" compression="zlib">
-   eJzt2+FqwjAUBtDihO2fbnPv/6rbYGUxNOuqbW9izoEgIsqF+jVpczsMAAAAAACkPqILgIq9RxdA1U7RBQSTDyiTjz4dowtoxJr5eP0a52T0PjfX7PDzuuUxajmDY+3mD7byFF3AHcba5YN7nSfGt0PxG/WLzke6FnsLqgFKovNBXVwrXhvnvsswPT9ODed5lvC/YU/5+t45HwCgX+la0HUJsIaWexBga3M9CM+7VAH1SNedf/Ug9JCNUm8G9Mxzm1CmrwfKWsrHXN/RlP/s7S/9TfqR58N9PPiV5+PWZ4n0YPGI1soHPKJL9r7lZ+0AAAAgZQ+Bnr3MfO4eKb3LM5Lujy29Rzq3t3ZLX8VeTkPd9QHU4hO/Kwa1
-  </data>
- </layer>
+  <layer name="Far" width="200" height="40">
+   <data encoding="base64" compression="zlib">
+    eJzt2VsKwyAQBdCsoo8VNN3/BvvbQC1Em9iZOQeE/AQcyFXjLAuc69YxIKuePMgLVckCtNkz4LvrjgGVXHYMqGZPPuSFSuQCPrt3Dshudt/jOfAuZLfOngD8MfmANvkY43ya22P2BIKzvkCbfECbfECb8ykAAABnqNb/qlYvY6rdX0avV77PVe3+Mnq90fMNv/a+Z8gHbK2NZ2B7Jox+PqQO/8rQZi0HAAAAiCf7nWf2+jhW9v5u9vo41sj3E2Ftlg9GjPTMIvTbIswRYKYXswgSvA==
+   </data>
+  </layer>
+  <layer name="Middle" width="200" height="40">
+   <properties>
+    <property name="test layer property" type="bool" value="true"/>
+   </properties>
+   <data encoding="base64" compression="zlib">
+    eJztm9tOw0AMBc0DPAEfAKIY6P9/I6kgqA25NInXa3dnpCOeqJxmZ+89CgCMcfwNAPwHPwCmwQ+AafDDlrvaBYAp+GHLZ5fDIF9VK4I94AfU4qXL60LeqlX3A34ATIMfvrA+yQV++MC6JCf4AdkpOSbjB2RmbFy2HJvxw5bh+2IOlRv8iA9rehueujwO8rzwP/gRk6l5A+PSNua+z7nvEj/KsqXPuhW2jHvRxkr8KMfWPmsN0dqTdnkvlA+/x/ijZT/G+vYM/XuksxSVyzZ8LBxvT1r1g/n9PlR8fJiKlyOt+gHbUKnrhbcj+AFLqPjNn6LNt/AjLyXniCpxnfAcS/ADelRyOeHhCH7ACZX67dvSkdO+99T+5FzO9y7vzz63BaKdFURBpX67tozVecv5Z94Kpzl5/3yHkb/s3V6iUr89Zwi0h0r9dpclUI+18+S58/1r5pAqedfg+NEOKuXuKl07ryb4sYZr+nKL+1kq9d85wY81LJ23WZy9qdCHZ0x2ou/dquBF5mRGJeZvB3pU6r9f0p4fKuv6ZG9H1tZH4iYTKtvbnYcje+ojMZMFlf3PWtIRi/pIvERHxbZPLuGIGtZHYiUiKmXPtKzW7X2dtd8hKZcH2XYf2CrDMzd1fPY9jnjWSeqmxl2HKHcgstRJ/PMNRu5JzA==
+   </data>
+  </layer>
+  <layer name="Near" width="200" height="40">
+   <data encoding="base64" compression="zlib">
+    eJzt2+FqwjAUBtDihO2fbnPv/6rbYGUxNOuqbW9izoEgIsqF+jVpczsMAAAAAACkPqILgIq9RxdA1U7RBQSTDyiTjz4dowtoxJr5eP0a52T0PjfX7PDzuuUxajmDY+3mD7byFF3AHcba5YN7nSfGt0PxG/WLzke6FnsLqgFKovNBXVwrXhvnvsswPT9ODed5lvC/YU/5+t45HwCgX+la0HUJsIaWexBga3M9CM+7VAH1SNedf/Ug9JCNUm8G9Mxzm1CmrwfKWsrHXN/RlP/s7S/9TfqR58N9PPiV5+PWZ4n0YPGI1soHPKJL9r7lZ+0AAAAgZQ+Bnr3MfO4eKb3LM5Lujy29Rzq3t3ZLX8VeTkPd9QHU4hO/Kwa1
+   </data>
+  </layer>
+ </group>
  <objectgroup name="Objects" offsetx="1" offsety="-2">
   <properties>
    <property name="another object layer property" value="salmon"/>

--- a/ParseTest/src/main.cpp
+++ b/ParseTest/src/main.cpp
@@ -27,6 +27,7 @@ source distribution.
 
 #include <tmxlite/Map.hpp>
 #include <tmxlite/ObjectGroup.hpp>
+#include <tmxlite/LayerGroup.hpp>
 
 #include <iostream>
 
@@ -37,7 +38,7 @@ int main()
     if (map.load("maps/platform.tmx"))
     {
         std::cout << "Loaded Map version: " << map.getVersion().upper << ", " << map.getVersion().lower << std::endl;
-        
+
         const auto& mapProperties = map.getProperties();
         std::cout << "Map has " << mapProperties.size() << " properties" << std::endl;
         for (const auto& prop : mapProperties)
@@ -54,6 +55,18 @@ int main()
         {
             std::cout << "Found Layer: " << layer->getName() << std::endl;
             std::cout << "Layer Type: " << int(layer->getType()) << std::endl;
+
+            if (layer->getType() == tmx::Layer::Type::Group)
+            {
+                std::cout << "Checking sublayers" << std::endl;
+                const auto& sublayers = layer->getLayerAs<tmx::LayerGroup>().getLayers();
+                std::cout << "LayerGroup has " << sublayers.size() << " layers" << std::endl;
+                for (const auto& sublayer : sublayers)
+                {
+                    std::cout << "Found Layer: " << sublayer->getName() << std::endl;
+                    std::cout << "Layer Type: " << int(sublayer->getType()) << std::endl;
+                }
+            }
 
             if(layer->getType() == tmx::Layer::Type::Object)
             {

--- a/tmxlite/include/tmxlite/Layer.hpp
+++ b/tmxlite/include/tmxlite/Layer.hpp
@@ -58,7 +58,7 @@ namespace tmx
     public:
         using Ptr = std::unique_ptr<Layer>;
 
-        explicit Layer() : m_opacity(1.f), m_visible(true) {};
+        Layer() : m_opacity(1.f), m_visible(true) {};
         virtual ~Layer() = default;
 
         /*

--- a/tmxlite/include/tmxlite/Layer.hpp
+++ b/tmxlite/include/tmxlite/Layer.hpp
@@ -47,6 +47,7 @@ namespace tmx
     class TileLayer;
     class ObjectGroup;
     class ImageLayer;
+    class LayerGroup;
     /*!
     \brief Represents a layer of a tmx format tile map.
     This is an abstract base class from which all layer
@@ -65,12 +66,14 @@ namespace tmx
         Tile: this layer is a TileLayer type
         Object: This layer is an ObjectGroup type
         Image: This layer is an ImageLayer type
+        Group: This layer is a LayerGroup type
         */
         enum class Type
         {
             Tile,
             Object,
-            Image
+            Image,
+            Group
         };
 
         /*!
@@ -84,7 +87,7 @@ namespace tmx
         \brief Use this to get a reference to the concrete layer type
         which this layer points to.
         Use getType() to return the type value of this layer and determine
-        if the concrete type is TileLayer, ObjectGroup or ImageLayer
+        if the concrete type is TileLayer, ObjectGroup, ImageLayer, or LayerGroup
         */
         template <typename T>
         T& getLayerAs();

--- a/tmxlite/include/tmxlite/LayerGroup.hpp
+++ b/tmxlite/include/tmxlite/LayerGroup.hpp
@@ -35,6 +35,11 @@ source distribution.
 
 namespace tmx
 {
+    /*!
+    \brief Layer groups are used to organize the layers of
+    the map in a hierarchy. They can contain all other layer
+    types including more layer groups to further nest layers.
+    */
     class TMXLITE_EXPORT_API LayerGroup final : public Layer
     {
     public:

--- a/tmxlite/include/tmxlite/LayerGroup.hpp
+++ b/tmxlite/include/tmxlite/LayerGroup.hpp
@@ -41,10 +41,10 @@ namespace tmx
 
         LayerGroup(const std::string& workDir, const Vector2u& tileCount);
         ~LayerGroup() = default;
-		LayerGroup(const LayerGroup&) = delete;
-		const LayerGroup& operator = (const LayerGroup&) = delete;
-		LayerGroup(LayerGroup&&) = default;
-		LayerGroup& operator = (LayerGroup&&) = default;
+        LayerGroup(const LayerGroup&) = delete;
+        const LayerGroup& operator = (const LayerGroup&) = delete;
+        LayerGroup(LayerGroup&&) = default;
+        LayerGroup& operator = (LayerGroup&&) = default;
 
 
         Type getType() const override { return Layer::Type::Group; }

--- a/tmxlite/include/tmxlite/LayerGroup.hpp
+++ b/tmxlite/include/tmxlite/LayerGroup.hpp
@@ -39,8 +39,13 @@ namespace tmx
     {
     public:
 
-        explicit LayerGroup(const std::string& workDir, const Vector2u& tileCount);
+        LayerGroup(const std::string& workDir, const Vector2u& tileCount);
         ~LayerGroup() = default;
+		LayerGroup(const LayerGroup&) = delete;
+		const LayerGroup& operator = (const LayerGroup&) = delete;
+		LayerGroup(LayerGroup&&) = default;
+		LayerGroup& operator = (LayerGroup&&) = default;
+
 
         Type getType() const override { return Layer::Type::Group; }
         void parse(const pugi::xml_node&) override;

--- a/tmxlite/include/tmxlite/LayerGroup.hpp
+++ b/tmxlite/include/tmxlite/LayerGroup.hpp
@@ -1,0 +1,72 @@
+/*********************************************************************
+Grant Gangi 2019
+
+tmxlite - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+#ifndef TMXLITE_LAYER_GROUP_HPP_
+#define TMXLITE_LAYER_GROUP_HPP_
+
+#include <tmxlite/Config.hpp>
+#include <tmxlite/Layer.hpp>
+#include <tmxlite/Types.hpp>
+
+#include <vector>
+
+namespace tmx
+{
+    class TMXLITE_EXPORT_API LayerGroup final : public Layer
+    {
+    public:
+
+        explicit LayerGroup(const std::string& workDir, const Vector2u& tileCount);
+        ~LayerGroup() = default;
+
+        Type getType() const override { return Layer::Type::Group; }
+        void parse(const pugi::xml_node&) override;
+
+        /*!
+        \brief Returns a reference to the vector containing the layer data.
+        Layers are pointer-to-baseclass, the concrete type of which can be
+        found via Layer::getType()
+        \see Layer
+        */
+        const std::vector<Layer::Ptr>& getLayers() const { return m_layers; }
+
+    private:
+
+        std::vector<Layer::Ptr> m_layers;
+
+        std::string m_workingDir;
+        Vector2u m_tileCount;
+    };
+
+    template <>
+    inline LayerGroup& Layer::getLayerAs<LayerGroup>()
+    {
+        assert(getType() == Type::Group);
+        return *dynamic_cast<LayerGroup*>(this);
+    }
+}
+
+#endif //TMXLITE_LAYER_GROUP_HPP_

--- a/tmxlite/src/CMakeLists.txt
+++ b/tmxlite/src/CMakeLists.txt
@@ -8,4 +8,5 @@ set(PROJECT_SRC
   ${PROJECT_DIR}/ObjectGroup.cpp
   ${PROJECT_DIR}/Property.cpp
   ${PROJECT_DIR}/TileLayer.cpp
+  ${PROJECT_DIR}/LayerGroup.cpp
   ${PROJECT_DIR}/Tileset.cpp)

--- a/tmxlite/src/LayerGroup.cpp
+++ b/tmxlite/src/LayerGroup.cpp
@@ -1,0 +1,94 @@
+/*********************************************************************
+Grant Gangi 2019
+
+tmxlite - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+#include "detail/pugixml.hpp"
+#include <tmxlite/LayerGroup.hpp>
+#include <tmxlite/FreeFuncs.hpp>
+#include <tmxlite/ObjectGroup.hpp>
+#include <tmxlite/ImageLayer.hpp>
+#include <tmxlite/TileLayer.hpp>
+#include <tmxlite/detail/Log.hpp>
+
+using namespace tmx;
+
+LayerGroup::LayerGroup(const std::string& workingDir, const Vector2u& tileCount)
+    : m_workingDir(workingDir),
+    m_tileCount(tileCount)
+{
+}
+
+//public
+void LayerGroup::parse(const pugi::xml_node& node)
+{
+    std::string attribString = node.name();
+    if (attribString != "group")
+    {
+        Logger::log("Node was not a group layer, node will be skipped.", Logger::Type::Error);
+        return;
+    }
+
+    setName(node.attribute("name").as_string());
+    setOpacity(node.attribute("opacity").as_float(1.f));
+    setVisible(node.attribute("visible").as_bool(true));
+    setOffset(node.attribute("offsetx").as_int(), node.attribute("offsety").as_int());
+
+    // parse children
+    for (const auto& child : node.children())
+    {
+        attribString = child.name();
+        if (attribString == "properties")
+        {
+            for (const auto& p : child.children())
+            {
+                addProperty(p);
+            }
+        }
+        else if (attribString == "layer")
+        {
+            m_layers.emplace_back(std::make_unique<TileLayer>(m_tileCount.x * m_tileCount.y));
+            m_layers.back()->parse(node);
+        }
+        else if (attribString == "objectgroup")
+        {
+            m_layers.emplace_back(std::make_unique<ObjectGroup>());
+            m_layers.back()->parse(node);
+        }
+        else if (attribString == "imagelayer")
+        {
+            m_layers.emplace_back(std::make_unique<ImageLayer>(m_workingDir));
+            m_layers.back()->parse(node);
+        }
+        else if (attribString == "group")
+        {
+            m_layers.emplace_back(std::make_unique<LayerGroup>(m_workingDir, m_tileCount));
+            m_layers.back()->parse(node);
+        }
+        else
+        {
+            LOG("Unidentified name " + attribString + ": node skipped", Logger::Type::Warning);
+        }
+    }
+}

--- a/tmxlite/src/Map.cpp
+++ b/tmxlite/src/Map.cpp
@@ -32,6 +32,7 @@ source distribution.
 #include <tmxlite/ObjectGroup.hpp>
 #include <tmxlite/ImageLayer.hpp>
 #include <tmxlite/TileLayer.hpp>
+#include <tmxlite/LayerGroup.hpp>
 #include <tmxlite/detail/Log.hpp>
 #include <tmxlite/detail/Android.hpp>
 
@@ -282,6 +283,11 @@ bool Map::load(const std::string& path)
                 m_properties.emplace_back();
                 m_properties.back().parse(child);
             }
+        }
+        else if (name == "group")
+        {
+            m_layers.emplace_back(std::make_unique<LayerGroup>(m_workingDirectory, m_tileCount));
+            m_layers.back()->parse(node);
         }
         else
         {

--- a/tmxlite/tmxlite.vcxproj
+++ b/tmxlite/tmxlite.vcxproj
@@ -255,6 +255,7 @@
     <ClInclude Include="include\tmxlite\FreeFuncs.hpp" />
     <ClInclude Include="include\tmxlite\ImageLayer.hpp" />
     <ClInclude Include="include\tmxlite\Layer.hpp" />
+    <ClInclude Include="include\tmxlite\LayerGroup.hpp" />
     <ClInclude Include="include\tmxlite\Map.hpp" />
     <ClInclude Include="include\tmxlite\Object.hpp" />
     <ClInclude Include="include\tmxlite\ObjectGroup.hpp" />
@@ -267,6 +268,7 @@
     <ClCompile Include="src\detail\pugixml.cpp" />
     <ClCompile Include="src\FreeFuncs.cpp" />
     <ClCompile Include="src\ImageLayer.cpp" />
+    <ClCompile Include="src\LayerGroup.cpp" />
     <ClCompile Include="src\Map.cpp" />
     <ClCompile Include="src\miniz.c" />
     <ClCompile Include="src\Object.cpp" />

--- a/tmxlite/tmxlite.vcxproj.filters
+++ b/tmxlite/tmxlite.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClInclude Include="include\tmxlite\Types.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\tmxlite\LayerGroup.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\FreeFuncs.cpp">
@@ -78,6 +81,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\detail\pugixml.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\LayerGroup.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This is a start for supporting the `<group>` tag added in version 1.0 of the TMX format. Let me know if my approach here doesn't make sense, or if I'm missing something major.

I ran the parse test and it seems to still be working, but I would like to update it to include nested layers within layer groups to make sure everything is functioning.