### PR TITLE
Preserve overwritten template instance AABB properties

### DIFF
--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -251,8 +251,16 @@ void Object::parseTemplate(const std::string& path, Map* map)
     if (templateObjects.count(path) != 0)
     {
         const auto& obj = templateObjects[path];
-        m_AABB.width = obj.m_AABB.width;
-        m_AABB.height = obj.m_AABB.height;
+
+        if (m_AABB.width == 0)
+        {
+            m_AABB.width = obj.m_AABB.width;
+        }
+
+        if (m_AABB.height == 0)
+        {
+            m_AABB.height = obj.m_AABB.height;
+        }
 
         m_tilesetName = obj.m_tilesetName;
 

--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -251,17 +251,7 @@ void Object::parseTemplate(const std::string& path, Map* map)
     if (templateObjects.count(path) != 0)
     {
         const auto& obj = templateObjects[path];
-
-        if (m_AABB.width == 0)
-        {
-            m_AABB.width = obj.m_AABB.width;
-        }
-
-        if (m_AABB.height == 0)
-        {
-            m_AABB.height = obj.m_AABB.height;
-        }
-
+        
         m_tilesetName = obj.m_tilesetName;
 
         if (m_name.empty())

--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -251,6 +251,15 @@ void Object::parseTemplate(const std::string& path, Map* map)
     if (templateObjects.count(path) != 0)
     {
         const auto& obj = templateObjects[path];
+        if (m_AABB.width == 0)
+        {
+            m_AABB.width = obj.m_AABB.width;
+        }
+
+        if (m_AABB.height == 0)
+        {
+            m_AABB.height = obj.m_AABB.height;
+        }
         
         m_tilesetName = obj.m_tilesetName;
 


### PR DESCRIPTION
Hi there,

I've been migrating my tilemap objects over to use Tiled's template system. However, I've encountered an issue.  Say I have a template object that is 32x32 in size in the template. I instantiate it and change the size (Lets say 96x24). The size I made that instance should be the size I get when I call `Object::getAABB()`

However, I get the original template size of 32x32. There is an assignment that takes place...
```cpp
//in Object.cpp
void Object::parseTemplate(const std::string& path, Map* map)
{
    // ...
 
   //apply any non-overridden object properties from the template
    if (templateObjects.count(path) != 0)
    {
        const auto& obj = templateObjects[path];
        m_AABB.width = obj.m_AABB.width;
        m_AABB.height = obj.m_AABB.height;

    // ...

    }
}
```
~~Instead there should be a check to see if the size is zero. Which I have included in my PR here.~~
I actually realized these simply shouldn't be here if we want to preserve the template instance size.
Suggestions? Should both be preserved? Or should there just be a check to see if the size of the AABB is zero, then replace with the template's size, like my original intention.

Thanks!