### PR TITLE
Added the Time.hpp header so example compiles on Mac

### DIFF
--- a/SFMLExample/src/SFMLOrthogonalLayer.hpp
+++ b/SFMLExample/src/SFMLOrthogonalLayer.hpp
@@ -44,6 +44,7 @@ are implemented.
 #include <SFML/Graphics/Vertex.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/Transformable.hpp>
+#include <SFML/System/Time.hpp>
 
 #include <memory>
 #include <vector>


### PR DESCRIPTION
I wasn't able to build the example using clang on Mac until I added the header.