### PR TITLE
Compile without RTTI and replace dynamic_cast by static_cast

### DIFF
--- a/tmxlite/CMakeLists.txt
+++ b/tmxlite/CMakeLists.txt
@@ -13,9 +13,9 @@ SET(PROJECT_STATIC_RUNTIME FALSE CACHE BOOL "Use statically linked standard/runt
 
 if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
   if(PROJECT_STATIC_RUNTIME)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -static")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fno-rtti -static")
   else()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fno-rtti")
   endif()
 endif()
 

--- a/tmxlite/include/tmxlite/ImageLayer.hpp
+++ b/tmxlite/include/tmxlite/ImageLayer.hpp
@@ -79,6 +79,6 @@ namespace tmx
     inline ImageLayer& Layer::getLayerAs<ImageLayer>()
     {
         assert(getType() == Type::Image);
-        return *dynamic_cast<ImageLayer*>(this);
+        return *static_cast<ImageLayer*>(this);
     }
 }

--- a/tmxlite/include/tmxlite/LayerGroup.hpp
+++ b/tmxlite/include/tmxlite/LayerGroup.hpp
@@ -74,6 +74,6 @@ namespace tmx
     inline LayerGroup& Layer::getLayerAs<LayerGroup>()
     {
         assert(getType() == Type::Group);
-        return *dynamic_cast<LayerGroup*>(this);
+        return *static_cast<LayerGroup*>(this);
     }
 }

--- a/tmxlite/include/tmxlite/ObjectGroup.hpp
+++ b/tmxlite/include/tmxlite/ObjectGroup.hpp
@@ -85,6 +85,6 @@ namespace tmx
     inline ObjectGroup& Layer::getLayerAs<ObjectGroup>()
     {
         assert(getType() == Type::Object);
-        return *dynamic_cast<ObjectGroup*>(this);
+        return *static_cast<ObjectGroup*>(this);
     }
 }

--- a/tmxlite/include/tmxlite/TileLayer.hpp
+++ b/tmxlite/include/tmxlite/TileLayer.hpp
@@ -105,6 +105,6 @@ namespace tmx
     inline TileLayer& Layer::getLayerAs<TileLayer>()
     {
         assert(getType() == Type::Tile);
-        return *dynamic_cast<TileLayer*>(this);
+        return *static_cast<TileLayer*>(this);
     }
 }


### PR DESCRIPTION
tmxlite seems to have chosen to not use RTTI capabilities in order to cast layers to their sub-classes. Instead it uses its own type encoding and provides the custom getLayerAs downcasting method.
However, the library is still using internally a useless expensive dynamic_cast where I claim a static_cast can do the job as safely and efficiently.

Speaking about safety, the code I propose exhibits undefined behaviours in the exact same situations than the original. Indeed, if performing a static_cast into a wrong type is UB, dereferencing the nullptr dynamic_cast produces for a wrong destination type is UB as well.

In terms of performance, it should be faster as the dynamic type lookup is now skipped (the code already does its own custom safety check in the assert just before). Moreover, the code can now be compiled with the -fno-rtti flag (also some free performance gain) and more importantly regain compatibility with -fno-rtti clients.