### PR TITLE
include windows.h instead of Windows.h

### DIFF
--- a/tmxlite/include/tmxlite/detail/Log.hpp
+++ b/tmxlite/include/tmxlite/detail/Log.hpp
@@ -40,7 +40,7 @@ source distribution.
 
 #ifdef _MSC_VER
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 #endif //_MSC_VER
 
 


### PR DESCRIPTION
Trying to cross compile tmxlite for windows on linux I ran into a problem with tmxlite trying to include Windows.h. While there is no general consensus on the msvc side of what is the correct casing of windows.h, mingw and wine seem to use the lower-case variant. Of course it can be worked around with a case insensitive FS, but it's easier this way.