### PR TITLE
Add meson build scripts

### DIFF
--- a/OpenGLExample/meson.build
+++ b/OpenGLExample/meson.build
@@ -1,0 +1,23 @@
+sdl2_dep = dependency('sdl2')
+sdl2image_dep = dependency('SDL2_image')
+opengl_dep = dependency('opengl')
+glm_dep = dependency('glm')
+glew_dep = dependency('glew')
+
+pvt_incdir = include_directories('src')
+
+executable('OpenGL_example',
+  'src/Game.cpp',
+  'src/main.cpp',
+  'src/MapLayer.cpp',
+  'src/OpenGL.cpp',
+  install: false,
+  include_directories: pvt_incdir,
+  dependencies: [
+	tmxlite_dep,
+	sdl2_dep,
+	sdl2image_dep,
+	opengl_dep,
+	glew_dep,
+  ],
+)

--- a/ParseTest/CMakeLists.txt
+++ b/ParseTest/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
 SET(PROJECT_STATIC_RUNTIME FALSE CACHE BOOL "Use statically linked standard/runtime libraries?")
+SET(PAUSE_AT_END TRUE CACHE BOOL "Wait for user input after tests have finished running")
 #SET(PROJECT_STATIC_TMX FALSE CACHE BOOL "Use statically linked tmxlite library?")
 
 if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
@@ -17,6 +18,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR APPLE)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14")
   endif()
 endif()
+
+SET(ASSETS_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+configure_file(src/config.h.in "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
 SET (CMAKE_CXX_FLAGS_DEBUG "-g -D_DEBUG_")
 SET (CMAKE_CXX_FLAGS_RELEASE "-O4 -DNDEBUG")
@@ -33,6 +37,8 @@ else()
   add_executable(${PROJECT_NAME} ${PROJECT_SRC})
 endif()
 
+target_include_directories(${PROJECT_NAME}
+  ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(${PROJECT_NAME}
   ${TMXLITE_LIBRARIES})
 

--- a/ParseTest/meson.build
+++ b/ParseTest/meson.build
@@ -1,0 +1,26 @@
+pvt_incdir = include_directories('src')
+
+conf = configuration_data()
+conf.set('ASSETS_PATH', meson.current_source_dir() / '')
+if get_option('pause_test')
+  conf.set('PAUSE_AT_END', true)
+endif
+
+project_config_file = configure_file(
+	input: 'src/config.h.in',
+	output: 'config.h',
+	configuration: conf,
+	format: 'cmake@'
+)
+
+exec_target = executable('tmxlite_parse_test',
+  'src/main.cpp',
+  project_config_file,
+  install: false,
+  include_directories: pvt_incdir,
+  dependencies: [
+	tmxlite_dep
+  ],
+)
+
+test(meson.project_name() + ' unit test', exec_target)

--- a/ParseTest/src/config.h.in
+++ b/ParseTest/src/config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#define ASSETS_PATH "@ASSETS_PATH@"
+#cmakedefine PAUSE_AT_END

--- a/ParseTest/src/main.cpp
+++ b/ParseTest/src/main.cpp
@@ -25,6 +25,7 @@ and must not be misrepresented as being the original software.
 source distribution.
 *********************************************************************/
 
+#include "config.h"
 #include <tmxlite/Map.hpp>
 #include <tmxlite/ObjectGroup.hpp>
 #include <tmxlite/LayerGroup.hpp>
@@ -36,7 +37,7 @@ int main()
 {
     tmx::Map map;
 
-    if (map.load("maps/platform.tmx"))
+    if (map.load(ASSETS_PATH "maps/platform.tmx"))
     {
         std::cout << "Loaded Map version: " << map.getVersion().upper << ", " << map.getVersion().lower << std::endl;
         if (map.isInfinite())
@@ -139,8 +140,10 @@ int main()
         std::cout << "Failed loading map" << std::endl;
     }
 
+#if defined(PAUSE_AT_END)
     std::cout << std::endl << "Press return to quit..." <<std::endl;
     std::cin.get();
+#endif
 
     return 0;
 }

--- a/SFMLExample/meson.build
+++ b/SFMLExample/meson.build
@@ -1,0 +1,17 @@
+sfml_graphics_dep = dependency('sfml-graphics')
+sfml_window_dep = dependency('sfml-window')
+sfml_system_dep = dependency('sfml-system')
+
+pvt_incdir = include_directories('src')
+
+executable('SFML_example',
+  'src/main.cpp',
+  install: false,
+  include_directories: pvt_incdir,
+  dependencies: [
+	tmxlite_dep,
+	sfml_graphics_dep,
+	sfml_window_dep,
+	sfml_system_dep,
+  ],
+)

--- a/meson.build
+++ b/meson.build
@@ -52,5 +52,7 @@ if cpp.get_argument_syntax() == 'msvc'
 endif
 
 subdir('tmxlite')
-subdir('OpenGLExample')
-subdir('SFMLExample')
+if get_option('build_examples')
+  subdir('OpenGLExample')
+  subdir('SFMLExample')
+endif

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project('tmxlite', 'cpp', 'c',
   default_options: [
 	'buildtype=release',
 	'cpp_std=c++14',
+	'warning_level=3',
 	'b_ndebug=if-release'
   ]
 )
@@ -12,17 +13,15 @@ cpp = meson.get_compiler('cpp')
 if get_option('use_rtti')
   if cpp.get_argument_syntax() == 'gcc'
 	if get_option('project_static_runtime')
-	  add_project_arguments('-Wall', '-static', language: ['cpp', 'c'])
-	else
-	  add_project_arguments('-Wall', language: ['cpp', 'c'])
+	  add_project_arguments('-static', language: ['cpp', 'c'])
 	endif
   endif
 else
   if cpp.get_argument_syntax() == 'gcc'
 	if get_option('project_static_runtime')
-	  add_project_arguments('-Wall', '-fno-rtti', '-static', language: ['cpp', 'c'])
+	  add_project_arguments('-fno-rtti', '-static', language: ['cpp', 'c'])
 	else
-	  add_project_arguments('-Wall', '-fno-rtti', language: ['cpp', 'c'])
+	  add_project_arguments('-fno-rtti', language: ['cpp', 'c'])
 	endif
   endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -52,3 +52,4 @@ if cpp.get_argument_syntax() == 'msvc'
 endif
 
 subdir('tmxlite')
+subdir('OpenGLExample')

--- a/meson.build
+++ b/meson.build
@@ -55,3 +55,6 @@ if get_option('build_examples')
   subdir('OpenGLExample')
   subdir('SFMLExample')
 endif
+if get_option('build_tests')
+  subdir('ParseTest')
+endif

--- a/meson.build
+++ b/meson.build
@@ -53,3 +53,4 @@ endif
 
 subdir('tmxlite')
 subdir('OpenGLExample')
+subdir('SFMLExample')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,54 @@
+project('tmxlite', 'cpp', 'c',
+  version: '1.2.1',
+  meson_version: '>=0.49.2',
+  default_options: [
+	'buildtype=release',
+	'cpp_std=c++14',
+	'b_ndebug=if-release'
+  ]
+)
+
+cpp = meson.get_compiler('cpp')
+if get_option('use_rtti')
+  if cpp.get_argument_syntax() == 'gcc'
+	if get_option('project_static_runtime')
+	  add_project_arguments('-Wall', '-static', language: ['cpp', 'c'])
+	else
+	  add_project_arguments('-Wall', language: ['cpp', 'c'])
+	endif
+  endif
+else
+  if cpp.get_argument_syntax() == 'gcc'
+	if get_option('project_static_runtime')
+	  add_project_arguments('-Wall', '-fno-rtti', '-static', language: ['cpp', 'c'])
+	else
+	  add_project_arguments('-Wall', '-fno-rtti', language: ['cpp', 'c'])
+	endif
+  endif
+endif
+
+binary_postfix = ''
+if get_option('default_library') == 'static'
+  if get_option('debug')
+	add_project_arguments('-D_DEBUG_', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
+	binary_postfix = '-s-d'
+  else
+	add_project_arguments('-O4', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
+	binary_postfix = '-s'
+  endif
+elif get_option('default_library') == 'shared'
+  if get_option('debug')
+	add_project_arguments('-D_DEBUG_', language: ['cpp', 'c'])
+	binary_postfix = '-d'
+  else
+	add_project_arguments('-O4', language: ['cpp', 'c'])
+  endif
+else
+  error('Unsupported option \'' + get_option('default_library') + '\' for project ' + meson.project_name())
+endif
+
+if cpp.get_argument_syntax() == 'msvc'
+  add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: ['cpp', 'c'])
+endif
+
+subdir('tmxlite')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('use_rtti', type: 'boolean', value: true, description: 'Use run time type information?', yield: true)
 option('project_static_runtime', type: 'boolean', value: false, description: 'Use statically linked standard/runtime libraries?', yield: true)
+option('build_examples', type: 'boolean', value: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('use_rtti', type: 'boolean', value: true, description: 'Use run time type information?', yield: true)
+option('project_static_runtime', type: 'boolean', value: false, description: 'Use statically linked standard/runtime libraries?', yield: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,5 @@
 option('use_rtti', type: 'boolean', value: true, description: 'Use run time type information?', yield: true)
 option('project_static_runtime', type: 'boolean', value: false, description: 'Use statically linked standard/runtime libraries?', yield: true)
 option('build_examples', type: 'boolean', value: false)
+option('build_tests', type: 'boolean', value: false)
+option('pause_test', type: 'boolean', value: true, description: 'Wait for user input after tests have finished running')

--- a/tmxlite/meson.build
+++ b/tmxlite/meson.build
@@ -1,0 +1,3 @@
+incdir = include_directories('include')
+
+subdir('src')

--- a/tmxlite/src/meson.build
+++ b/tmxlite/src/meson.build
@@ -1,0 +1,20 @@
+tmxlite_lib = library(meson.project_name() + binary_postfix,
+  'detail/pugixml.cpp',
+  'FreeFuncs.cpp',
+  'ImageLayer.cpp',
+  'Map.cpp',
+  'miniz.c',
+  'Object.cpp',
+  'ObjectGroup.cpp',
+  'Property.cpp',
+  'TileLayer.cpp',
+  'LayerGroup.cpp',
+  'Tileset.cpp',
+  install: true,
+  include_directories: incdir,
+)
+
+tmxlite_dep = declare_dependency(
+  link_with: tmxlite_lib,
+  include_directories: incdir,
+)


### PR DESCRIPTION
This should be pretty equivalent to the existing cmake files. Configuring is done normally as `meson setup <path_to_tmxlite_source>`, which will default to a release build, or passing `-Dbuildtype=debug` for a debug build. Other options are in `meson_options.txt` and are the same as the cmake ones, just lower case to match meson's style.

With this change tmxlite can be easily used as a subproject from other meson projects, ie: `subproject('tmxlite')`