### PR TITLE
Tileset::getImagePath() should return a reference

### DIFF
--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -172,7 +172,7 @@ namespace tmx
         working directory. Use this to load the texture required by whichever
         method you choose to render the map.
         */
-        const std::string getImagePath() const { return m_imagePath; }
+        const std::string& getImagePath() const { return m_imagePath; }
         /*!
         \brief Returns the size of the tile set image in pixels.
          */


### PR DESCRIPTION
Probably a typo, every other function returns "const std::string&" when this one returns "const std::string".
Also problematic when wrapping the getter into another class returning const reference (causing dangling reference).