### PR TITLE
Add support for Object Types.

### DIFF
--- a/tmxlite/include/tmxlite/ObjectTypes.hpp
+++ b/tmxlite/include/tmxlite/ObjectTypes.hpp
@@ -53,10 +53,6 @@ namespace tmx
 
         ObjectTypes() = default;
         ~ObjectTypes() = default;
-        ObjectTypes(const ObjectTypes&) = delete;
-        ObjectTypes& operator  = (const ObjectTypes&) = delete;
-        ObjectTypes(ObjectTypes&&) = default;
-        ObjectTypes& operator = (ObjectTypes&&) = default;
 
         /*!
         \brief Attempts to parse the object types at the given location.

--- a/tmxlite/include/tmxlite/ObjectTypes.hpp
+++ b/tmxlite/include/tmxlite/ObjectTypes.hpp
@@ -1,0 +1,93 @@
+/*********************************************************************
+Raphaël Frantz 2020
+
+tmxlite - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+#pragma once
+
+#include <tmxlite/Property.hpp>
+
+#include <string>
+#include <vector>
+
+namespace tmx
+{
+    /*!
+    \brief Parser for Tiled object types export format.
+    Link to the specification: https://doc.mapeditor.org/fr/latest/manual/custom-properties/#predefining-properties.
+    */
+    class TMXLITE_EXPORT_API ObjectTypes final
+    {
+    public:
+        /*!
+        \brief Types that stores all predefined properties for all objects of this type.
+        To take less spaces, they are not exported by default into maps.
+        */
+        struct Type
+        {
+            std::string name;
+            Colour colour;
+            std::vector<Property> properties;
+        };
+
+        ObjectTypes() = default;
+        ~ObjectTypes() = default;
+        ObjectTypes(const ObjectTypes&) = delete;
+        ObjectTypes& operator  = (const ObjectTypes&) = delete;
+        ObjectTypes(ObjectTypes&&) = default;
+        ObjectTypes& operator = (ObjectTypes&&) = default;
+
+        /*!
+        \brief Attempts to parse the object types at the given location.
+        \param std::string Path to object types file to try to parse
+        \returns true if object types was parsed successfully else returns false.
+        In debug mode this will attempt to log any errors to the console.
+        */
+        bool load(const std::string&);
+
+        /*!
+        \brief Loads an object types from a document stored in a string
+        \param data A std::string containing the object types to load
+        \param workingDir A std::string containing the working directory
+        in which to find files.
+        \returns true if successful, else false
+        */
+        bool loadFromString(const std::string& data, const std::string& workingDir);
+
+        /*!
+        \brief Returns all predefined types and their default values.
+        */
+        const std::vector<Type>& getTypes() const { return m_types; }
+
+    private:
+        std::string m_workingDirectory;
+        std::vector<Type> m_types;
+
+        bool parseObjectTypesNode(const pugi::xml_node&);
+
+        //always returns false so we can return this
+        //on load failure
+        bool reset();
+    };
+}

--- a/tmxlite/include/tmxlite/ObjectTypes.hpp
+++ b/tmxlite/include/tmxlite/ObjectTypes.hpp
@@ -1,5 +1,5 @@
 /*********************************************************************
-Raphaël Frantz 2020
+Raphaël Frantz 2021
 
 tmxlite - Zlib license.
 

--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -68,8 +68,10 @@ namespace tmx
 
         /*!
         \brief Attempts to parse the given node as a property
+        \param isObjectTypes Set to true if the parsing is done from an object types files.
         */
-        void parse(const pugi::xml_node&);
+        void parse(const pugi::xml_node&, bool isObjectTypes = false);
+
         /*!
         \brief Returns the type of data stored in the property.
         This should generally be called first before trying to

--- a/tmxlite/src/CMakeLists.txt
+++ b/tmxlite/src/CMakeLists.txt
@@ -9,4 +9,5 @@ set(PROJECT_SRC
   ${PROJECT_DIR}/Property.cpp
   ${PROJECT_DIR}/TileLayer.cpp
   ${PROJECT_DIR}/LayerGroup.cpp
-  ${PROJECT_DIR}/Tileset.cpp)
+  ${PROJECT_DIR}/Tileset.cpp
+  ${PROJECT_DIR}/ObjectTypes.cpp)

--- a/tmxlite/src/ObjectTypes.cpp
+++ b/tmxlite/src/ObjectTypes.cpp
@@ -1,5 +1,5 @@
 /*********************************************************************
-Raphaël Frantz 2020
+Raphaël Frantz 2021
 
 tmxlite - Zlib license.
 

--- a/tmxlite/src/ObjectTypes.cpp
+++ b/tmxlite/src/ObjectTypes.cpp
@@ -1,0 +1,177 @@
+/*********************************************************************
+Raphaël Frantz 2020
+
+tmxlite - Zlib license.
+
+This software is provided 'as-is', without any express or
+implied warranty. In no event will the authors be held
+liable for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute
+it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented;
+you must not claim that you wrote the original software.
+If you use this software in a product, an acknowledgment
+in the product documentation would be appreciated but
+is not required.
+
+2. Altered source versions must be plainly marked as such,
+and must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any
+source distribution.
+*********************************************************************/
+
+
+#include <tmxlite/FreeFuncs.hpp>
+#include <tmxlite/ObjectTypes.hpp>
+#include "detail/pugixml.hpp"
+#include <tmxlite/detail/Log.hpp>
+
+namespace
+{
+    //TODO Copied from Map.cpp, maybe move into FreeFuncs.hpp
+    std::string getFilePath(const std::string& path)
+    {
+        static auto searchFunc = [](const char separator, const std::string& path)->std::string
+        {
+            std::size_t i = path.rfind(separator, path.length());
+            if (i != std::string::npos)
+            {
+                return(path.substr(0, i + 1));
+            }
+
+            return "";
+        };
+
+
+#ifdef _WIN32 //try windows formatted paths first
+        std::string retVal = searchFunc('\\', path);
+        if (!retVal.empty()) return retVal;
+#endif
+
+        return searchFunc('/', path);
+    }
+}
+
+using namespace tmx;
+
+bool ObjectTypes::load(const std::string &path)
+{
+    reset();
+
+    //open the doc
+    pugi::xml_document doc;
+    auto result = doc.load_file(path.c_str());
+    if (!result)
+    {
+        Logger::log("Failed opening " + path, Logger::Type::Error);
+        Logger::log("Reason: " + std::string(result.description()), Logger::Type::Error);
+        return false;
+    }
+
+    //make sure we have consistent path separators
+    m_workingDirectory = path;
+    std::replace(m_workingDirectory.begin(), m_workingDirectory.end(), '\\', '/');
+    m_workingDirectory = getFilePath(m_workingDirectory);
+
+    if (!m_workingDirectory.empty() &&
+        m_workingDirectory.back() == '/')
+    {
+        m_workingDirectory.pop_back();
+    }
+
+
+    //find the node and bail if it doesn't exist
+    auto node = doc.child("objecttypes");
+    if (!node)
+    {
+        Logger::log("Failed opening object types: " + path + ", no objecttype node found", Logger::Type::Error);
+        return reset();
+    }
+
+    return parseObjectTypesNode(node);
+}
+
+bool ObjectTypes::loadFromString(const std::string &data, const std::string &workingDir)
+{
+    reset();
+
+    //open the doc
+    pugi::xml_document doc;
+    auto result = doc.load_string(data.c_str());
+    if (!result)
+    {
+        Logger::log("Failed opening object types", Logger::Type::Error);
+        Logger::log("Reason: " + std::string(result.description()), Logger::Type::Error);
+        return false;
+    }
+
+    //make sure we have consistent path separators
+    m_workingDirectory = workingDir;
+    std::replace(m_workingDirectory.begin(), m_workingDirectory.end(), '\\', '/');
+    m_workingDirectory = getFilePath(m_workingDirectory);
+
+    if (!m_workingDirectory.empty() &&
+        m_workingDirectory.back() == '/')
+    {
+        m_workingDirectory.pop_back();
+    }
+
+
+    //find the node and bail if it doesn't exist
+    auto node = doc.child("objecttypes");
+    if (!node)
+    {
+        Logger::log("Failed object types: no objecttypes node found", Logger::Type::Error);
+        return reset();
+    }
+
+    return parseObjectTypesNode(node);
+}
+
+bool ObjectTypes::parseObjectTypesNode(const pugi::xml_node &node)
+{
+    //<objecttypes> <-- node
+    //  <objecttype name="Character" color="#1e47ff">
+    //    <property>...
+
+    //parse types
+    for(const auto& child : node.children())
+    {
+        std::string attribString = child.name();
+        if (attribString == "objecttype")
+        {
+            Type type;
+
+            //parse the metadata of the type
+            type.name = child.attribute("name").as_string();
+            type.colour = colourFromString(child.attribute("color").as_string("#FFFFFFFF"));;
+
+            //parse the default properties of the type
+            for (const auto& p : child.children())
+            {
+                Property prop;
+                prop.parse(p, true);
+                type.properties.push_back(prop);
+            }
+
+            m_types.push_back(type);
+        }
+        else
+        {
+            LOG("Unidentified name " + attribString + ": node skipped", Logger::Type::Warning);
+        }
+    }
+
+    return true;
+}
+
+bool ObjectTypes::reset()
+{
+    m_workingDirectory.clear();
+    m_types.clear();
+    return false;
+}

--- a/tmxlite/src/Property.cpp
+++ b/tmxlite/src/Property.cpp
@@ -38,8 +38,11 @@ Property::Property()
 }
 
 //public
-void Property::parse(const pugi::xml_node& node)
+void Property::parse(const pugi::xml_node& node, bool isObjectTypes)
 {
+    // The value attribute name is different in object types
+    const char *const valueAttribute = isObjectTypes ? "default" : "value";
+
     std::string attribData = node.name();
     if (attribData != "property")
     {
@@ -52,26 +55,26 @@ void Property::parse(const pugi::xml_node& node)
     attribData = node.attribute("type").as_string("string");
     if (attribData == "bool")
     {
-        attribData = node.attribute("value").as_string("false");
+        attribData = node.attribute(valueAttribute).as_string("false");
         m_boolValue = (attribData == "true");
         m_type = Type::Boolean;
         return;
     }
     else if (attribData == "int")
     {
-        m_intValue = node.attribute("value").as_int(0);
+        m_intValue = node.attribute(valueAttribute).as_int(0);
         m_type = Type::Int;
         return;
     }
     else if (attribData == "float")
     {
-        m_floatValue = node.attribute("value").as_float(0.f);
+        m_floatValue = node.attribute(valueAttribute).as_float(0.f);
         m_type = Type::Float;
         return;
     }
     else if (attribData == "string")
     {
-        m_stringValue = node.attribute("value").as_string();
+        m_stringValue = node.attribute(valueAttribute).as_string();
 
         //if value is empty, try getting the child value instead
         //as this is how multiline string properties are stored.
@@ -79,25 +82,25 @@ void Property::parse(const pugi::xml_node& node)
         {
             m_stringValue = node.child_value();
         }
-        
+
         m_type = Type::String;
         return;
     }
     else if (attribData == "color")
     {
-        m_colourValue = colourFromString(node.attribute("value").as_string("#FFFFFFFF"));
+        m_colourValue = colourFromString(node.attribute(valueAttribute).as_string("#FFFFFFFF"));
         m_type = Type::Colour;
         return;
     }
     else if (attribData == "file")
     {
-        m_stringValue = node.attribute("value").as_string();
+        m_stringValue = node.attribute(valueAttribute).as_string();
         m_type = Type::File;
         return;
     }
     else if (attribData == "object")
     {
-        m_intValue = node.attribute("value").as_int(0);
+        m_intValue = node.attribute(valueAttribute).as_int(0);
         m_type = Type::Object;
         return;
     }


### PR DESCRIPTION
Related to recent issue #94 and question #90.

The `object_types.xml` is parsed totally independantly from the map, but we can go further on this basis :)

Notes:
- Tiled do not name this feature other than "object types", so I use the same terminology (the class is named "ObjectTypes") but maybe a more explicit one like "BaseType" or something similar may be also good.
- It would be good to add these default values for the objects (related to integration into `tmx::Map`), because the use case will be likely: search in object -> if not found search in object_types.xml


You can find a basic repository for testing it [here](https://github.com/Eren121/tmxlite-TestObjectTypes).