### PR TITLE
Add Property factory

### DIFF
--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -66,6 +66,14 @@ namespace tmx
         Property();
         ~Property() = default;
 
+        static Property fromBoolean(bool value);
+        static Property fromFloat(float value);
+        static Property fromInt(int value);
+        static Property fromString(const std::string& value);
+        static Property fromColour(const Colour& value);
+        static Property fromFile(const std::string& value);
+        static Property fromObject(int value);
+
         /*!
         \brief Attempts to parse the given node as a property
         \param isObjectTypes Set to true if the parsing is done from an object types files.

--- a/tmxlite/src/Property.cpp
+++ b/tmxlite/src/Property.cpp
@@ -37,6 +37,62 @@ Property::Property()
 {
 }
 
+Property Property::fromBoolean(bool value)
+{
+    Property p;
+    p.m_type = Type::Boolean;
+    p.m_boolValue = value;
+    return p;
+}
+
+Property Property::fromFloat(float value)
+{
+    Property p;
+    p.m_type = Type::Float;
+    p.m_floatValue = value;
+    return p;
+}
+
+Property Property::fromInt(int value)
+{
+    Property p;
+    p.m_type = Type::Int;
+    p.m_intValue = value;
+    return p;
+}
+
+Property Property::fromString(const std::string& value)
+{
+    Property p;
+    p.m_type = Type::String;
+    p.m_stringValue = value;
+    return p;
+}
+
+Property Property::fromColour(const Colour& value)
+{
+    Property p;
+    p.m_type = Type::Colour;
+    p.m_colourValue = value;
+    return p;
+}
+
+Property Property::fromFile(const std::string& value)
+{
+    Property p;
+    p.m_type = Type::File;
+    p.m_stringValue = value;
+    return p;
+}
+
+Property Property::fromObject(int value)
+{
+    Property p;
+    p.m_type = Type::Object;
+    p.m_intValue = value;
+    return p;
+}
+
 //public
 void Property::parse(const pugi::xml_node& node, bool isObjectTypes)
 {


### PR DESCRIPTION
Related to #96.

One problem was that multiple C++ type can represent different TMX Property type, so it was a bit annoying with overloaded constructors.
I opted for simple and verbose factory methods. I could use template, with some assertions, but I think it's cleaner that way.