### PR TITLE
bug fix : access to the int value of the object property

### DIFF
--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -105,7 +105,7 @@ namespace tmx
         /*!
         \brief Returns the property's value as an integer
         */
-        int getIntValue() const { assert(m_type == Type::Int); return m_intValue; }
+        int getIntValue() const { assert(m_type == Type::Int || m_type == Type::Object); return m_intValue; }
 
         /*!
         \brief Returns the property's value as a string


### PR DESCRIPTION
Tiled Object property have int value which  represent unique ID of the object, but actualy we can't get this value because of this line : 
```c++
int getIntValue() const { assert(m_type == Type::Int); return m_intValue; }
```

Actualy we have : 

```c++
int getObjectValue() const { assert(m_type == Type::Object); return m_intValue; }
```
to get the value but for me it's strange to have assert error with getIntValue .

xml example :
```xml
<property name="WayPoint0" type="object" value="49"/>
```