### PR TITLE
update to be compatible with tiled 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Debug
 Release
 
 *.swp
+/.vs/tmxlite
+/tmxlite/tmxlite.vcxproj.user

--- a/tmxlite/include/tmxlite/Object.hpp
+++ b/tmxlite/include/tmxlite/Object.hpp
@@ -112,10 +112,15 @@ namespace tmx
         const std::string& getName() const { return m_name; }
         
         /*!
-        \brief Returns the type of the Object, as defined in the editor
+        \brief Returns the type (equal to class) of the Object, as defined in the editor Tiled < 1.9
         */
-        const std::string& getType() const { return m_type; }
-        
+        const std::string& getType() const { return m_class; }
+
+        /*!
+       \brief Returns the class (equal to type) of the Object, as defined in the editor Tiled 1.9
+       */
+        const std::string& getClass() const { return m_class; }
+
         /*!
         \brief Returns the position of the Object in pixels
         */
@@ -193,7 +198,7 @@ namespace tmx
     private:
         std::uint32_t m_UID;
         std::string m_name;
-        std::string m_type;
+        std::string m_class;
         Vector2f m_position;
         FloatRect m_AABB;
         float m_rotation;

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -99,7 +99,7 @@ namespace tmx
             \brief The position of the tile within the image.
             */
             Vector2u imagePosition;
-            std::string type;
+            std::string Class;
         };
             
         /*!

--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -59,7 +59,13 @@ void Object::parse(const pugi::xml_node& node, Map* map)
 
     m_UID = node.attribute("id").as_int();
     m_name = node.attribute("name").as_string();
-    m_type = node.attribute("type").as_string();
+
+    m_class = node.attribute("type").as_string();
+    if (m_class.empty())
+    {
+        m_class = node.attribute("class").as_string();
+    }
+    
     m_position.x = node.attribute("x").as_float();
     m_AABB.left = m_position.x;
     m_position.y = node.attribute("y").as_float();
@@ -274,9 +280,9 @@ void Object::parseTemplate(const std::string& path, Map* map)
             m_name = obj.m_name;
         }
 
-        if (m_type.empty())
+        if (m_class.empty())
         {
-            m_type = obj.m_type;
+            m_class = obj.m_class;
         }
 
         if (m_rotation == 0)

--- a/tmxlite/src/Tileset.cpp
+++ b/tmxlite/src/Tileset.cpp
@@ -353,7 +353,12 @@ void Tileset::parseTileNode(const pugi::xml_node& node, Map* map)
     }
 
     tile.probability = node.attribute("probability").as_int(100);
-    tile.type = node.attribute("type").as_string();
+
+    tile.Class = node.attribute("type").as_string();
+	if (tile.Class.empty())
+	{
+        tile.Class = node.attribute("class").as_string();
+	}
     
     //by default we set the tile's values as in an Image tileset
     tile.imagePath = m_imagePath;


### PR DESCRIPTION
With the new tiled version 1.9, Type are rename to class.

https://doc.mapeditor.org/fr/latest/reference/tmx-changelog/#tiled-1-9

This code change works with older versions of tiled.