### PR TITLE
Add parallax factor

### DIFF
--- a/tmxlite/include/tmxlite/Layer.hpp
+++ b/tmxlite/include/tmxlite/Layer.hpp
@@ -125,6 +125,11 @@ namespace tmx
         const Vector2i& getOffset() const { return m_offset; }
 
         /*!
+        \brief Returns the parallax factor
+        */
+        const Vector2f& getParallaxFactor() const { return m_parallaxFactor;  }
+
+        /*!
         \brief Returns the size of the layer, in pixels.
         This will be the same as the map size for fixed size maps.
         */
@@ -142,6 +147,7 @@ namespace tmx
         void setVisible(bool visible) { m_visible = visible; }
         void setOffset(std::int32_t x, std::int32_t y) { m_offset = Vector2i(x, y); }
         void setSize(std::uint32_t width, std::uint32_t height) { m_size = Vector2u(width, height); }
+        void setParallaxFactor(float x, float y) { m_parallaxFactor.x = x; m_parallaxFactor.y = y; }
         void addProperty(const pugi::xml_node& node) { m_properties.emplace_back(); m_properties.back().parse(node); }
 
     private:
@@ -150,6 +156,7 @@ namespace tmx
         bool m_visible;
         Vector2i m_offset;
         Vector2u m_size;
+        Vector2f m_parallaxFactor;
 
         std::vector<Property> m_properties;
     };

--- a/tmxlite/src/TileLayer.cpp
+++ b/tmxlite/src/TileLayer.cpp
@@ -55,6 +55,7 @@ void TileLayer::parse(const pugi::xml_node& node, Map*)
     setVisible(node.attribute("visible").as_bool(true));
     setOffset(node.attribute("offsetx").as_int(), node.attribute("offsety").as_int());
     setSize(node.attribute("width").as_uint(), node.attribute("height").as_uint());
+    setParallaxFactor(node.attribute("parallaxx").as_float(), node.attribute("parallaxy").as_float());
 
     for (const auto& child : node.children())
     {


### PR DESCRIPTION
I add the tiled layer scrolling factor.

![image](https://user-images.githubusercontent.com/24843378/196302309-ce78eee7-7299-4733-9bdf-be0f01426bc3.png)


parallaxx: Horizontal [parallax factor](https://doc.mapeditor.org/en/stable/manual/layers/#parallax-factor) for this layer. Defaults to 1. (since 1.5)

parallaxy: Vertical [parallax factor](https://doc.mapeditor.org/en/stable/manual/layers/#parallax-factor) for this layer. Defaults to 1. (since 1.5)


