### PR TITLE
clearing animated tiles during reset

### DIFF
--- a/tmxlite/src/Map.cpp
+++ b/tmxlite/src/Map.cpp
@@ -352,5 +352,7 @@ bool Map::reset()
     m_templateObjects.clear();
     m_templateTilesets.clear();
 
+    m_animTiles.clear();
+
     return false;
 }


### PR DESCRIPTION
When loading multiple levels, tmx::Map is not resetted completely: The animated tiles were not cleared, playing wrong animations in the new level.
 
Easily demonstrated by loading 
    map.load("assets/demo.tmx");
    map.load("assets/demo2.tmx");

in main.cpp of SFMLExample: 
The program shows animations from the first map. If second map is loaded alone, the map shows no animation.