### PR TITLE
add image repeat flags

### DIFF
--- a/tmxlite/include/tmxlite/ImageLayer.hpp
+++ b/tmxlite/include/tmxlite/ImageLayer.hpp
@@ -69,12 +69,26 @@ namespace tmx
         */
         const Vector2u& getImageSize() const { return m_imageSize; }
 
+        /*!
+        \brief Returns true if the image drawn by this layer is repeated along 
+        the X axis.
+        */
+        bool hasRepeatX() const { return m_hasRepeatX; }
+
+        /*!
+        \brief Returns true if the image drawn by this layer is repeated along 
+        the Y axis.
+        */
+        bool hasRepeatY() const { return m_hasRepeatY; }
+
     private:
         std::string m_workingDir;
         std::string m_filePath;
         Colour m_transparencyColour;
         bool m_hasTransparency;
         Vector2u m_imageSize;
+        bool m_hasRepeatX;
+        bool m_hasRepeatY;
     };
 
     template <>

--- a/tmxlite/src/ImageLayer.cpp
+++ b/tmxlite/src/ImageLayer.cpp
@@ -38,7 +38,9 @@ using namespace tmx;
 
 ImageLayer::ImageLayer(const std::string& workingDir)
     : m_workingDir      (workingDir),
-    m_hasTransparency   (false)
+    m_hasTransparency   (false),
+    m_hasRepeatX        (false),
+    m_hasRepeatY        (false)
 {
 
 }

--- a/tmxlite/src/ImageLayer.cpp
+++ b/tmxlite/src/ImageLayer.cpp
@@ -67,6 +67,9 @@ void ImageLayer::parse(const pugi::xml_node& node, Map*)
         setTintColour(colourFromString(tintColour));
     }
 
+    m_hasRepeatX = node.attribute("repeatx").as_bool(false);
+    m_hasRepeatY = node.attribute("repeaty").as_bool(false);
+
     for (const auto& child : node.children())
     {
         attribName = child.name();


### PR DESCRIPTION
Added the image repeat flags for x and y axis to ImageLayer.  

This was introduced with Tiled 1.8
[reference: tmx-changelog](https://doc.mapeditor.org/en/stable/reference/tmx-changelog/#tiled-1-8)
[reference: tmx-map-format](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#imagelayer)
