### PR TITLE
Better performance for large Tilesets

### DIFF
--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -34,7 +34,6 @@ source distribution.
 #include <string>
 #include <vector>
 #include <array>
-#include <unordered_set>
 
 namespace pugi
 {

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -276,6 +276,7 @@ namespace tmx
         bool m_hasTransparency;
 
         std::vector<Terrain> m_terrainTypes;
+        std::vector<size_t> m_tile_index;
         std::vector<Tile> m_tiles;
 
         void reset();
@@ -283,7 +284,8 @@ namespace tmx
         void parseOffsetNode(const pugi::xml_node&);
         void parsePropertyNode(const pugi::xml_node&);
         void parseTerrainNode(const pugi::xml_node&);
+        Tile& newTile(std::uint32_t ID);
         void parseTileNode(const pugi::xml_node&, Map*);
-        void createMissingTile(std::uint32_t ID, std::unordered_set<std::uint32_t>* created);
+        void createMissingTile(std::uint32_t ID);
     };
 }

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -34,6 +34,7 @@ source distribution.
 #include <string>
 #include <vector>
 #include <array>
+#include <unordered_set>
 
 namespace pugi
 {
@@ -283,6 +284,6 @@ namespace tmx
         void parsePropertyNode(const pugi::xml_node&);
         void parseTerrainNode(const pugi::xml_node&);
         void parseTileNode(const pugi::xml_node&, Map*);
-        void createMissingTile(std::uint32_t ID);
+        void createMissingTile(std::uint32_t ID, std::unordered_set<std::uint32_t>* created);
     };
 }

--- a/tmxlite/src/Tileset.cpp
+++ b/tmxlite/src/Tileset.cpp
@@ -123,6 +123,9 @@ void Tileset::parse(pugi::xml_node node, Map* map)
     m_tileCount = node.attribute("tilecount").as_int();
     m_columnCount = node.attribute("columns").as_int();
 
+    m_tile_index.reserve(m_tileCount);
+    m_tiles.reserve(m_tileCount);
+
     std::string objectAlignment = node.attribute("objectalignment").as_string();
     if (!objectAlignment.empty())
     {
@@ -216,43 +219,26 @@ void Tileset::parse(pugi::xml_node node, Map* map)
     }
 
     //if the tsx file does not declare every tile, we create the missing ones
-    std::unordered_set<std::uint32_t> created;
-    for(auto& tile: m_tiles) created.insert(tile.ID);
     if (m_tiles.size() != getTileCount())
-    {
         for (std::uint32_t ID = 0 ; ID < getTileCount() ; ID++)
-        {
-            createMissingTile(ID, &created);
-        }
-    }
-
-    //sort these just to make sure when we request last GID we get the corrtect value
-    std::sort(m_tiles.begin(), m_tiles.end(), [](const Tile& t1, const Tile& t2) {return t1.ID < t2.ID; });
+            createMissingTile(ID);
 }
 
 std::uint32_t Tileset::getLastGID() const
 {
-    assert(!m_tiles.empty());
-    return m_firstGID + m_tiles.back().ID;
+    return m_firstGID + m_tile_index.size() - 1;
 }
 
 const Tileset::Tile* Tileset::getTile(std::uint32_t id) const
 {
-    if (!hasTile(id))
-    {
+    if (!hasTile(id)) {
         return nullptr;
     }
     
     //corrects the ID. Indices and IDs are different.
-    id = (getLastGID() - m_firstGID) - (getLastGID() - id);
-    
-    const auto itr = std::find_if(m_tiles.begin(), m_tiles.end(), 
-        [id](const Tile& tile)
-    {
-            return tile.ID == id;
-    });
-
-    return (itr == m_tiles.end()) ? nullptr : &(*itr);
+    id -= m_firstGID;
+    id = m_tile_index[id];
+    return id ? &m_tiles[id - 1] : nullptr;
 }
 
 //private
@@ -273,6 +259,7 @@ void Tileset::reset()
     m_transparencyColour = { 0, 0, 0, 0 };
     m_hasTransparency = false;
     m_terrainTypes.clear();
+    m_tile_index.clear();
     m_tiles.clear();
 }
 
@@ -321,12 +308,20 @@ void Tileset::parseTerrainNode(const pugi::xml_node& node)
     }
 }
 
+Tileset::Tile& Tileset::newTile(std::uint32_t ID) {
+    Tile& tile = (m_tiles.emplace_back(), m_tiles.back());
+    if(m_tile_index.size() <= ID)
+        m_tile_index.resize(ID + 1, 0);
+    m_tile_index[ID] = m_tiles.size();
+    tile.ID = ID;
+    return tile;
+}
+
 void Tileset::parseTileNode(const pugi::xml_node& node, Map* map)
 {
     assert(map);
 
-    Tile tile;
-    tile.ID = node.attribute("id").as_int();
+    Tile& tile = newTile(node.attribute("id").as_int());
     if (node.attribute("terrain"))
     {
         std::string data = node.attribute("terrain").as_string();
@@ -432,18 +427,14 @@ void Tileset::parseTileNode(const pugi::xml_node& node, Map* map)
             }
         }
     }
-    m_tiles.push_back(tile);
 }
 
-void Tileset::createMissingTile(std::uint32_t ID, std::unordered_set<std::uint32_t>* created)
+void Tileset::createMissingTile(std::uint32_t ID)
 {
     //first, we check if the tile does not yet exist
-    if(created && created->count(ID) == 0) return;
-    if(!created && std::any_of(m_tiles.begin(), m_tiles.end(), [ID](const Tile& tile) { return tile.ID == ID; }))
-        return;
+    if(m_tile_index.size() > ID && m_tile_index[ID]) return;
 
-    Tile tile;
-    tile.ID = ID;
+    Tile& tile = newTile(ID);
     tile.imagePath = m_imagePath;
     tile.imageSize = m_tileSize;
 
@@ -451,7 +442,4 @@ void Tileset::createMissingTile(std::uint32_t ID, std::unordered_set<std::uint32
     std::int32_t columnIndex = ID / m_columnCount;
     tile.imagePosition.x = m_margin + rowIndex * (m_tileSize.x + m_spacing);
     tile.imagePosition.y = m_margin + columnIndex * (m_tileSize.y + m_spacing);
-
-    m_tiles.push_back(tile);
-    if(created) created->insert(ID);
 }


### PR DESCRIPTION
This creates an index of tiles by their ID, removing the need for a sort in the vector of tiles. It also makes getTile() and createMissingTile() constant operations.