### PR TITLE
Fix flip-function calls

### DIFF
--- a/SFMLExample/CMakeLists.txt
+++ b/SFMLExample/CMakeLists.txt
@@ -1,6 +1,7 @@
+cmake_minimum_required(VERSION 2.8.12)
+
 project(SFML_example)
 SET(PROJECT_NAME SFML_example)
-cmake_minimum_required(VERSION 2.8)
 
 if(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build (Debug or Release)" FORCE)
@@ -21,7 +22,7 @@ endif()
 SET (CMAKE_CXX_FLAGS_DEBUG "-g -D_DEBUG_")
 SET (CMAKE_CXX_FLAGS_RELEASE "-O4 -DNDEBUG")
 
-find_package(TMXLITE REQUIRED)
+find_package(tmxlite REQUIRED)
 find_package(SFML 2 REQUIRED graphics window system)
 
 include_directories(

--- a/SFMLExample/src/SFMLOrthogonalLayer.hpp
+++ b/SFMLExample/src/SFMLOrthogonalLayer.hpp
@@ -366,54 +366,54 @@ private:
                !(bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //0100
-                flipY(v0,v1,v2,v3);
+                flipY(v0,v1,v2,v3,v4,v5);
             }
             else if((bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                !(bits & tmx::TileLayer::FlipFlag::Vertical) &&
                !(bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //1000
-                flipX(v0,v1,v2,v3);
+                flipX(v0,v1,v2,v3,v4,v5);
             }
             else if((bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                (bits & tmx::TileLayer::FlipFlag::Vertical) &&
                !(bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //1100
-                flipY(v0,v1,v2,v3);
-                flipX(v0,v1,v2,v3);
+                flipY(v0,v1,v2,v3,v4,v5);
+                flipX(v0,v1,v2,v3,v4,v5);
             }
             else if(!(bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                !(bits & tmx::TileLayer::FlipFlag::Vertical) &&
                (bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //0010
-                flipD(v0,v1,v2,v3);
+                flipD(v0,v1,v2,v3,v4,v5);
             }
             else if(!(bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                 (bits & tmx::TileLayer::FlipFlag::Vertical) &&
                 (bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //0110
-                flipX(v0,v1,v2,v3);
-                flipD(v0,v1,v2,v3);
+                flipX(v0,v1,v2,v3,v4,v5);
+                flipD(v0,v1,v2,v3,v4,v5);
             }
             else if((bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                 !(bits & tmx::TileLayer::FlipFlag::Vertical) &&
                 (bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //1010
-                flipY(v0,v1,v2,v3);
-                flipD(v0,v1,v2,v3);
+                flipY(v0,v1,v2,v3,v4,v5);
+                flipD(v0,v1,v2,v3,v4,v5);
            }
             else if((bits & tmx::TileLayer::FlipFlag::Horizontal) &&
                (bits & tmx::TileLayer::FlipFlag::Vertical) &&
                (bits & tmx::TileLayer::FlipFlag::Diagonal) )
             {
                 //1110
-                flipY(v0,v1,v2,v3);
-                flipX(v0,v1,v2,v3);
-                flipD(v0,v1,v2,v3);
+                flipY(v0,v1,v2,v3,v4,v5);
+                flipX(v0,v1,v2,v3,v4,v5);
+                flipD(v0,v1,v2,v3,v4,v5);
             }
         }
 


### PR DESCRIPTION
- Update CMake version to the minimum support version by current CMake
- Fix warning about tmxlite target

## How to test?

I wrote a simpler example, given that the provided CMake script is quite tricky to get working:

```cmake
cmake_minimum_required(VERSION 3.24)
project(tmxlitetest LANGUAGES CXX)

include(FetchContent)

FetchContent_Declare(SFML
    GIT_REPOSITORY https://github.com/SFML/SFML.git
    GIT_TAG 2.6.0)
FetchContent_GetProperties(SFML)
if(NOT SFML_POPULATED)
    FetchContent_Populate(SFML)
    add_subdirectory(${sfml_SOURCE_DIR} ${sfml_BINARY_DIR} EXCLUDE_FROM_ALL)
endif()

FetchContent_Declare(tmxlite
    GIT_REPOSITORY https://github.com/fallahn/tmxlite.git
    GIT_TAG master)
FetchContent_GetProperties(tmxlite)
if(NOT tmxlite_POPULATED)
    FetchContent_Populate(tmxlite)
    add_subdirectory("${tmxlite_SOURCE_DIR}/tmxlite" ${tmxlite_BINARY_DIR} EXCLUDE_FROM_ALL)
endif()

add_executable(tmxlitetest main.cpp)
target_link_libraries(tmxlitetest PRIVATE sfml-graphics tmxlite)
target_compile_features(tmxlitetest PRIVATE cxx_std_17)

install(TARGETS tmxlitetest DESTINATION .)
install(DIRECTORY "assets/" DESTINATION "assets/")
```

assets, main.cpp and SFMLOrthogonalLayer.hpp are copied from the repo