### PR TITLE
Partial Tiled 1.8 Support

### DIFF
--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -32,6 +32,7 @@ source distribution.
 
 #include <string>
 #include <cassert>
+#include <vector>
 
 namespace pugi
 {
@@ -60,6 +61,7 @@ namespace tmx
             Colour,
             File,
             Object,
+            Class,
             Undef
         };
             
@@ -137,7 +139,10 @@ namespace tmx
         };
         std::string m_stringValue;
         std::string m_name;
+        std::string m_propertyType;
+        
         Colour m_colourValue;
+        std::vector<std::shared_ptr<Property>> m_classValue;
 
         Type m_type;
     };

--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -127,7 +127,7 @@ namespace tmx
         /*!
         \brief Returns an array of properties
         */
-        const std::vector<std::shared_ptr<Property>>& getClassValue() const {assert(m_type == Type::Class); return m_classValue; }
+        const std::vector<Property>& getClassValue() const {assert(m_type == Type::Class); return m_classValue; }
 
         /*!
         \brief Returns an the propertytype value
@@ -152,7 +152,7 @@ namespace tmx
         std::string m_propertyType;
         
         Colour m_colourValue;
-        std::vector<std::shared_ptr<Property>> m_classValue;
+        std::vector<Property> m_classValue;
 
         Type m_type;
     };

--- a/tmxlite/include/tmxlite/Property.hpp
+++ b/tmxlite/include/tmxlite/Property.hpp
@@ -125,6 +125,16 @@ namespace tmx
         const std::string& getFileValue() const { assert(m_type == Type::File); return m_stringValue; }
 
         /*!
+        \brief Returns an array of properties
+        */
+        const std::vector<std::shared_ptr<Property>>& getClassValue() const {assert(m_type == Type::Class); return m_classValue; }
+
+        /*!
+        \brief Returns an the propertytype value
+        */
+        const std::string getPropertyType() const {assert(m_type == Type::Class); return m_propertyType; }
+        
+        /*!
         \brief Returns the property's value as an integer object handle
         */
         int getObjectValue() const { assert(m_type == Type::Object); return m_intValue; }

--- a/tmxlite/src/Property.cpp
+++ b/tmxlite/src/Property.cpp
@@ -164,4 +164,19 @@ void Property::parse(const pugi::xml_node& node, bool isObjectTypes)
         m_type = Type::Object;
         return;
     }
+    else if (attribData == "class")
+    {
+        m_type = Type::Class;
+        m_propertyType = node.attribute("propertytype").as_string("string");
+        
+        if (node.first_child().name() == "properties")
+        {
+            for(const auto& childProp : node.first_child().children())
+            {
+                m_classValue.emplace_back(std::make_shared<Property>());
+                m_classValue.back()->parse(childProp);
+            }
+        }
+        return;
+    }
 }

--- a/tmxlite/src/Property.cpp
+++ b/tmxlite/src/Property.cpp
@@ -174,8 +174,8 @@ void Property::parse(const pugi::xml_node& node, bool isObjectTypes)
         {
             for(const auto& childProp : node.first_child().children())
             {
-                m_classValue.emplace_back(std::make_shared<Property>());
-                m_classValue.back()->parse(childProp);
+                m_classValue.emplace_back();
+                m_classValue.back().parse(childProp);
             }
         }
         return;

--- a/tmxlite/src/Property.cpp
+++ b/tmxlite/src/Property.cpp
@@ -167,9 +167,10 @@ void Property::parse(const pugi::xml_node& node, bool isObjectTypes)
     else if (attribData == "class")
     {
         m_type = Type::Class;
-        m_propertyType = node.attribute("propertytype").as_string("string");
-        
-        if (node.first_child().name() == "properties")
+        m_propertyType = node.attribute("propertytype").as_string("null");
+
+        const std::string firstChildName = node.first_child().name();
+        if (firstChildName == "properties")
         {
             for(const auto& childProp : node.first_child().children())
             {


### PR DESCRIPTION
- Properties of the type "class" can now be parsed, a reference to the users "propertytype" is now also stored if set
- "class" type properties now recursively load child properties

This partially implements this [change log](https://doc.mapeditor.org/en/stable/reference/tmx-changelog/#tiled-1-8).
I threw this together pretty quick but I'm happy to make changes if this isn't good enough right now, I'm not a fan of the recursive vectors for example but it got the job done for me!