### PR TITLE
fix: resolveFilePath won't return the correct file path when using "../" pass workingDir

### DIFF
--- a/tmxlite/include/tmxlite/FreeFuncs.hpp
+++ b/tmxlite/include/tmxlite/FreeFuncs.hpp
@@ -175,9 +175,22 @@ namespace tmx
             result = path.find(match);
         }
 
-        if (workingDir.empty()) return path;
-
         std::string outPath = workingDir;
+        if (workingDir.empty()) {
+#ifndef __ANDROID__
+            // Going up the folder tree
+            for (auto j = 0u; j < count; ++j) {
+                if (j != 0)
+                    outPath.push_back('/');
+                outPath.append("..");
+            }
+            if (!outPath.empty()) {
+                path = outPath + '/' + path;
+            }
+#endif
+            return path;
+        }
+
         for (auto i = 0u; i < count; ++i)
         {
             result = outPath.find_last_of('/');
@@ -185,10 +198,26 @@ namespace tmx
             {
                 outPath = outPath.substr(0, result);
             }
+            else {
+                // Going up the folder tree
+                if (!outPath.empty()) {
+                    outPath = "";
+                    for (auto j = i + 1u; j < count; ++j) {
+                        if (j != i + 1u)
+                            outPath.push_back('/');
+                        outPath.append("..");
+                    }
+                    break;
+                }
+            }
         }
+
 // this does only work on windows       
 #ifndef __ANDROID__
-        return outPath + '/' + path;
+        if (!outPath.empty())
+            return outPath + '/' + path;
+        else
+            return path;
 #endif
 
 // todo: make resolveFilePath work with subfolders on 

--- a/tmxlite/src/Object.cpp
+++ b/tmxlite/src/Object.cpp
@@ -222,7 +222,7 @@ void Object::parseTemplate(const std::string& path, Map* map)
     //load the template if not already loaded
     if (templateObjects.count(path) == 0)
     {
-        auto templatePath = map->getWorkingDirectory() + "/" + path;
+        auto templatePath = resolveFilePath(path, map->getWorkingDirectory());
 
         pugi::xml_document doc;
         if (!doc.load_file(templatePath.c_str()))


### PR DESCRIPTION
Hi. This is my first every PR to any open source project so it's really bad code.
I have fix the problem where going up pass workingDir won't return the correct file path. 
So far, i have test it on my own project, parseTest, SFMLExample and it's working. (I didn't tested SDL2Example because it's kind of painful to setup even with SFMLExample) 