### PR TITLE
Support the locked attribute for image layers

### DIFF
--- a/tmxlite/include/tmxlite/ImageLayer.hpp
+++ b/tmxlite/include/tmxlite/ImageLayer.hpp
@@ -59,7 +59,7 @@ namespace tmx
         const Colour& getTransparencyColour() const { return m_transparencyColour; }
 
         /*!
-        \brief Returns true if the image used by this layer specifically states a 
+        \brief Returns true if the image used by this layer specifically states a
         colour to use as transparency
         */
         bool hasTransparency() const { return m_hasTransparency; }
@@ -70,16 +70,21 @@ namespace tmx
         const Vector2u& getImageSize() const { return m_imageSize; }
 
         /*!
-        \brief Returns true if the image drawn by this layer is repeated along 
+        \brief Returns true if the image drawn by this layer is repeated along
         the X axis.
         */
         bool hasRepeatX() const { return m_hasRepeatX; }
 
         /*!
-        \brief Returns true if the image drawn by this layer is repeated along 
+        \brief Returns true if the image drawn by this layer is repeated along
         the Y axis.
         */
         bool hasRepeatY() const { return m_hasRepeatY; }
+
+        /*!
+        \brief Returns true if the image drawn by this layer is locked.
+         */
+        bool locked() const {return m_locked;}
 
     private:
         std::string m_workingDir;
@@ -89,6 +94,7 @@ namespace tmx
         Vector2u m_imageSize;
         bool m_hasRepeatX;
         bool m_hasRepeatY;
+        bool m_locked;
     };
 
     template <>

--- a/tmxlite/src/ImageLayer.cpp
+++ b/tmxlite/src/ImageLayer.cpp
@@ -72,6 +72,7 @@ void ImageLayer::parse(const pugi::xml_node& node, Map*)
 
     m_hasRepeatX = node.attribute("repeatx").as_bool(false);
     m_hasRepeatY = node.attribute("repeaty").as_bool(false);
+    m_locked = node.attribute("locked").as_bool(false);
 
     for (const auto& child : node.children())
     {


### PR DESCRIPTION
Needed to use this for a project, it's a short change so I figured I'd commit it here.

<img width="332" height="171" alt="image" src="https://github.com/user-attachments/assets/19205c3d-baaa-4d0d-a4c2-8f2bed836750" />
