### PR TITLE
Package Update

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,46 +1,46 @@
 project('tmxlite', 'cpp', 'c',
-  version: '1.4.4',
-  meson_version: '>=0.49.2',
+  version: '1.4.5',
+  meson_version: '>=1.11',
   default_options: [
-	'buildtype=release',
-	'cpp_std=c++14',
-	'warning_level=3',
-	'b_ndebug=if-release'
+    'buildtype=release',
+    'cpp_std=c++14',
+    'warning_level=3',
+    'b_ndebug=if-release'
   ]
 )
 
 cpp = meson.get_compiler('cpp')
 if get_option('use_rtti')
   if cpp.get_argument_syntax() == 'gcc'
-	if get_option('project_static_runtime')
-	  add_project_arguments('-static', language: ['cpp', 'c'])
-	endif
+    if get_option('project_static_runtime')
+      add_project_arguments('-static', language: ['cpp', 'c'])
+    endif
   endif
 else
   if cpp.get_argument_syntax() == 'gcc'
-	if get_option('project_static_runtime')
-	  add_project_arguments('-fno-rtti', '-static', language: ['cpp', 'c'])
-	else
-	  add_project_arguments('-fno-rtti', language: ['cpp', 'c'])
-	endif
+    if get_option('project_static_runtime')
+      add_project_arguments('-fno-rtti', '-static', language: ['cpp', 'c'])
+    else
+      add_project_arguments('-fno-rtti', language: ['cpp', 'c'])
+    endif
   endif
 endif
 
 binary_postfix = ''
 if get_option('default_library') == 'static'
   if get_option('debug')
-	add_project_arguments('-D_DEBUG_', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
-	binary_postfix = '-s-d'
+    add_project_arguments('-D_DEBUG_', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
+    binary_postfix = '-s-d'
   else
-	add_project_arguments('-O3', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
-	binary_postfix = '-s'
+    add_project_arguments('-O3', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
+    binary_postfix = '-s'
   endif
 elif get_option('default_library') == 'shared'
   if get_option('debug')
-	add_project_arguments('-D_DEBUG_', language: ['cpp', 'c'])
-	binary_postfix = '-d'
+    add_project_arguments('-D_DEBUG_', language: ['cpp', 'c'])
+    binary_postfix = '-d'
   else
-	add_project_arguments('-O3', language: ['cpp', 'c'])
+	  add_project_arguments('-O3', language: ['cpp', 'c'])
   endif
 else
   error('Unsupported option \'' + get_option('default_library') + '\' for project ' + meson.project_name())
@@ -67,6 +67,6 @@ if get_option('build_examples')
   subdir('OpenGLExample')
   subdir('SFMLExample')
 endif
-if get_option('build_tests')
-  subdir('ParseTest')
+  if get_option('build_tests')
+    subdir('ParseTest')
 endif

--- a/meson.build
+++ b/meson.build
@@ -3,13 +3,18 @@ project('tmxlite', 'cpp', 'c',
   meson_version: '>=1.0.0',  # Earliest modern release that supports oldest supported Python (3.11)
   default_options: [
     'buildtype=release',
-    'cpp_std=c++14',
+    # 'cpp_std=c++14',
+    # 'c_std=c11',
     'warning_level=3',
     'b_ndebug=if-release',
   ]
 )
 
 cpp = meson.get_compiler('cpp')
+if cpp.get_argument_syntax() != 'msvc'  # msvc is being a dufus
+  add_project_arguments('-std=c++14', language: ['cpp'])
+endif
+
 if get_option('use_rtti')
   if cpp.get_argument_syntax() == 'gcc'
     if get_option('project_static_runtime')
@@ -32,7 +37,7 @@ if get_option('default_library') == 'static'
     add_project_arguments('-D_DEBUG_', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
     binary_postfix = '-s-d'
   else
-    add_project_arguments('-O3', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
+    add_project_arguments('-Doptimization=3', '-DTMXLITE_STATIC', language: ['cpp', 'c'])
     binary_postfix = '-s'
   endif
 elif get_option('default_library') == 'shared'
@@ -40,7 +45,7 @@ elif get_option('default_library') == 'shared'
     add_project_arguments('-D_DEBUG_', language: ['cpp', 'c'])
     binary_postfix = '-d'
   else
-	  add_project_arguments('-O3', language: ['cpp', 'c'])
+	  add_project_arguments('-Doptimization=3', language: ['cpp', 'c'])
   endif
 else
   error('Unsupported option \'' + get_option('default_library') + '\' for project ' + meson.project_name())

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
 project('tmxlite', 'cpp', 'c',
   version: '1.4.5',
-  meson_version: '>=1.11',
+  meson_version: '>=1.0.0',  # Earliest modern release that supports oldest supported Python (3.11)
   default_options: [
     'buildtype=release',
     'cpp_std=c++14',
     'warning_level=3',
-    'b_ndebug=if-release'
+    'b_ndebug=if-release',
   ]
 )
 

--- a/tmxlite/CMakeLists.txt
+++ b/tmxlite/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
-project(tmxlite VERSION 1.4.4)
+cmake_minimum_required(VERSION 3.10)
+project(tmxlite VERSION 1.4.5)
 SET(PROJECT_NAME tmxlite)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
@@ -52,7 +52,7 @@ endif()
 
 #disable msvc warning
 if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -64,29 +64,29 @@ include(${PROJECT_DIR}/CMakeLists.txt)
 
 #if we want external zip and xml libs find them and tell the compiler
 if(USE_EXTLIBS)
-    add_definitions(-DUSE_EXTLIBS)
-    add_definitions(-DUSE_ZSTD)
-    
-    SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
-    
-    find_package(ZLIB REQUIRED)
-    find_package(PUGIXML REQUIRED)
-    find_package(Zstd REQUIRED)
-    
-    include_directories(${ZLIB_INCLUDE_DIRS} ${PUGIXML_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR})
-    
+  add_definitions(-DUSE_EXTLIBS)
+  add_definitions(-DUSE_ZSTD)
+
+  SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+
+  find_package(ZLIB REQUIRED)
+  find_package(PUGIXML REQUIRED)
+  find_package(Zstd REQUIRED)
+
+  include_directories(${ZLIB_INCLUDE_DIRS} ${PUGIXML_INCLUDE_DIR} ${ZSTD_INCLUDE_DIR})
+
 else()
-    #add miniz and pugixml from source
-    SET(PROJECT_SRC ${PROJECT_SRC} ${LIB_SRC})
-    
-    if(USE_ZSTD)
-        add_definitions(-DUSE_ZSTD)
-    
-        SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
-        find_package(Zstd REQUIRED)
-        include_directories(${ZSTD_INCLUDE_DIR})
-    endif()
-    
+  # add miniz and pugixml from source
+  SET(PROJECT_SRC ${PROJECT_SRC} ${LIB_SRC})
+
+  if(USE_ZSTD)
+    add_definitions(-DUSE_ZSTD)
+
+    SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+    find_package(Zstd REQUIRED)
+    include_directories(${ZSTD_INCLUDE_DIR})
+  endif()
+
 endif()
 
 if(WIN32)
@@ -94,7 +94,7 @@ if(WIN32)
     add_library(${PROJECT_NAME} STATIC ${PROJECT_SRC})
   else()
     add_library(${PROJECT_NAME} SHARED ${PROJECT_SRC})
-  endif()   
+  endif()
 else()
   if(TMXLITE_STATIC_LIB)
     add_library(${PROJECT_NAME} STATIC ${PROJECT_SRC})
@@ -104,11 +104,11 @@ else()
 endif()
 
 if(USE_EXTLIBS)
-    target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES} ${PUGIXML_LIBRARY} ${ZSTD_LIBRARY})
+  target_link_libraries(${PROJECT_NAME} ${ZLIB_LIBRARIES} ${PUGIXML_LIBRARY} ${ZSTD_LIBRARY})
 else()
-    if(USE_ZSTD)
-    target_link_libraries(${PROJECT_NAME} ${ZSTD_LIBRARY})    
-    endif()    
+  if(USE_ZSTD)
+    target_link_libraries(${PROJECT_NAME} ${ZSTD_LIBRARY})
+  endif()
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tmxlite.pc.in ${CMAKE_CURRENT_BINARY_DIR}/tmxlite.pc
@@ -121,7 +121,7 @@ install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/tmxlite DESTINATION ${CMAK
 if(TMXLITE_STATIC_LIB)
   install(TARGETS ${PROJECT_NAME} EXPORT tmxlite-targets DESTINATION ${CMAKE_INSTALL_LIBDIR})
 else()
-  install(TARGETS ${PROJECT_NAME} EXPORT tmxlite-targets 
+  install(TARGETS ${PROJECT_NAME} EXPORT tmxlite-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/tmxlite/include/tmxlite/Tileset.hpp
+++ b/tmxlite/include/tmxlite/Tileset.hpp
@@ -109,7 +109,7 @@ namespace tmx
             Vector2u imagePosition;
             std::string className;
         };
-            
+
         /*!
         \brief Terrain information with which one
         or more tiles may be associated.
@@ -117,7 +117,7 @@ namespace tmx
         struct Terrain final
         {
             std::string name;
-            std::uint32_t tileID = -1;
+            uint32_t tileID = static_cast<uint32_t>(-1);
             std::vector<Property> properties;
         };
 
@@ -277,7 +277,7 @@ namespace tmx
         /*!
          \brief Checks if a tiled ID is in the range of the first ID and the last ID
          \param id Tile ID
-         \return 
+         \return
          */
         bool hasTile(std::uint32_t id) const { return id >= m_firstGID && id <= getLastGID(); };
 

--- a/tmxlite/src/Map.cpp
+++ b/tmxlite/src/Map.cpp
@@ -113,8 +113,8 @@ bool Map::parseMapNode(const pugi::xml_node& mapNode)
         return reset();
     }
 
-    m_version.upper = STOI(attribString.substr(0, pointPos));
-    m_version.lower = STOI(attribString.substr(pointPos + 1));
+    m_version.upper = static_cast<uint16_t>(STOI(attribString.substr(0, pointPos)));
+    m_version.lower = static_cast<uint16_t>(STOI(attribString.substr(pointPos + 1)));
 
     m_class = mapNode.attribute("class").as_string();
 

--- a/tmxlite/src/Tileset.cpp
+++ b/tmxlite/src/Tileset.cpp
@@ -182,49 +182,49 @@ bool Tileset::parse(pugi::xml_node node, Map* map)
     }
 
     const auto& children = node.children();
-    for (const auto& node : children)
+    for (const auto& childNode : children)
     {
-        std::string name = node.name();
+        std::string name = childNode.name();
         if (name == "image")
         {
             //TODO this currently doesn't cover embedded images
             //mostly because I can't figure out how to export them
             //from the Tiled editor... but also resource handling
             //should be handled by the renderer, not the parser.
-            attribString = node.attribute("source").as_string();
+            attribString = childNode.attribute("source").as_string();
             if (attribString.empty())
             {
                 Logger::log("Tileset image node has missing source property, tile set not loaded", Logger::Type::Error);
                 return reset();
             }
             m_imagePath = resolveFilePath(attribString, m_workingDir);
-            if (node.attribute("trans"))
+            if (childNode.attribute("trans"))
             {
-                attribString = node.attribute("trans").as_string();
+                attribString = childNode.attribute("trans").as_string();
                 m_transparencyColour = colourFromString(attribString);
                 m_hasTransparency = true;
             }
-            if (node.attribute("width") && node.attribute("height"))
+            if (childNode.attribute("width") && childNode.attribute("height"))
             {
-                m_imageSize.x = node.attribute("width").as_int();
-                m_imageSize.y = node.attribute("height").as_int();
+                m_imageSize.x = childNode.attribute("width").as_int();
+                m_imageSize.y = childNode.attribute("height").as_int();
             }
         }
         else if (name == "tileoffset")
         {
-            parseOffsetNode(node);
+            parseOffsetNode(childNode);
         }
         else if (name == "properties")
         {
-            parsePropertyNode(node);
+            parsePropertyNode(childNode);
         }
         else if (name == "terraintypes")
         {
-            parseTerrainNode(node);
+            parseTerrainNode(childNode);
         }
         else if (name == "tile")
         {
-            parseTileNode(node, map);
+            parseTileNode(childNode, map);
         }
     }
 
@@ -252,7 +252,7 @@ const Tileset::Tile* Tileset::getTile(std::uint32_t id) const
     {
         return nullptr;
     }
-    
+
     //corrects the ID. Indices and IDs are different.
     id -= m_firstGID;
     id = m_tileIndex[id];
@@ -382,12 +382,12 @@ void Tileset::parseTileNode(const pugi::xml_node& node, Map* map)
     {
         tile.className = node.attribute("class").as_string();
     }
-    
+
     //by default we set the tile's values as in an Image tileset
     tile.imagePath = m_imagePath;
     tile.imageSize = m_tileSize;
 
-    if (m_columnCount != 0) 
+    if (m_columnCount != 0)
     {
         std::uint32_t rowIndex = tile.ID % m_columnCount;
         std::uint32_t columnIndex = tile.ID / m_columnCount;


### PR DESCRIPTION
_Build only tested with MSVC locally with no test runs, will need runners_

**The Important Stuff**
- Update CMake minimum to 3.10 (the future minimum)
- Update Meson minimum to 1.0.0
- Bump TMXLite version to 1.4.5 in both CMake and Meson

**Fixing Warnings**
- Used `-Doptimization=3` instead of `-O3` to satisfy Meson builds
- Only specify C++14 minimum if not MSVC or it'll whine
- Cast `-1` to a `uint32_t` so it isn't implicit
- Same story with the STOI lines, explicitly casting to `uint16_t`
- Rename iterable `node` to `childNode` to not shadow function param name

**Extras**
- Made indentation consistent in CMake and Meson files
- VSCode did some cleanup with whitespace apparently